### PR TITLE
Allow selecting camera source for inference

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,6 +44,22 @@ async def ws():
         await websocket.send(frame_b64)
         await asyncio.sleep(0.05)
 
+@app.route("/set_camera", methods=["POST"])
+async def set_camera():
+    global camera
+    data = await request.get_json()
+    source_val = data.get("source", "")
+    if camera and camera.isOpened():
+        camera.release()
+    try:
+        source = int(source_val)
+    except ValueError:
+        source = source_val
+    camera = cv2.VideoCapture(source)
+    if not camera.isOpened():
+        return jsonify({"status": "error"}), 400
+    return jsonify({"status": "ok"})
+
 # ✅ หยุด stream
 @app.route('/stop_stream', methods=["POST"])
 async def stop_stream():

--- a/templates/inference.html
+++ b/templates/inference.html
@@ -5,7 +5,8 @@
 </head>
 <body>
     <h2>Inference with Saved ROI</h2>
-    <button onclick="loadAndStart()">Load ROI & Start Stream</button>
+    <input id="cameraSource" placeholder="Camera source">
+    <button id="startButton">Load ROI & Start Stream</button>
     <p id="status"></p>
     <div style="position: relative; display: inline-block;">
         <img id="video" width="640" height="480" />
@@ -18,8 +19,20 @@
         const video = document.getElementById("video");
         const canvas = document.getElementById("canvas");
         const ctx = canvas.getContext("2d");
+        document.getElementById("startButton").onclick = loadAndStart;
 
         async function loadAndStart() {
+            const source = document.getElementById("cameraSource").value;
+            const camRes = await fetch("/set_camera", {
+                method: "POST",
+                headers: {"Content-Type": "application/json"},
+                body: JSON.stringify({source})
+            });
+            if (!camRes.ok) {
+                document.getElementById("status").innerText = "Camera error";
+                return;
+            }
+
             const res = await fetch("/load_roi");
             const data = await res.json();
             document.getElementById("status").innerText = "Loaded: " + data.filename;


### PR DESCRIPTION
## Summary
- add camera source input and start button to inference page
- call new `/set_camera` route before starting websocket stream
- implement `/set_camera` to switch camera source

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688c8d8f275c832b9ceb1dbe7606b15a