### PR TITLE
เพิ่มงานอินเฟอเรนซ์แบบพื้นหลังและปรับ WebSocket

### DIFF
--- a/templates/inference.html
+++ b/templates/inference.html
@@ -38,6 +38,8 @@
             document.getElementById("status").innerText = "Loaded: " + data.filename;
             rois = data.rois;
 
+            await fetch("/start_inference", { method: "POST" });
+
             socket = new WebSocket("ws://" + location.host + "/ws");
             socket.onmessage = function(event) {
                 video.src = 'data:image/jpeg;base64,' + event.data;

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -26,7 +26,8 @@
         const canvas = document.getElementById("canvas");
         const ctx = canvas.getContext("2d");
 
-        function startStream() {
+        async function startStream() {
+            await fetch("/start_inference", { method: "POST" });
             socket = new WebSocket("ws://" + location.host + "/ws");
             socket.onmessage = function(event) {
                 video.src = 'data:image/jpeg;base64,' + event.data;
@@ -101,12 +102,6 @@
             });
         }
     
-        function stopStream() {
-            if (socket) socket.close();
-            fetch("/stop_stream", { method: "POST" })
-                .then(res => res.json())
-                .then(data => alert("Stream stopped"));
-        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## สรุป
- เพิ่มงาน `run_inference_loop` ทำงานอ่านเฟรมและส่งผ่านคิวให้ WebSocket
- สร้าง endpoint `/start_inference` และ `/stop_inference` เพื่อควบคุมงานพื้นหลัง
- ปรับหน้า ROI และ Inference ให้เรียกใช้งาน endpoint ใหม่

## การทดสอบ
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d6ecaea4c832b87759de608d3cb80