### PR TITLE
feat: allow large file uploads

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,6 +11,8 @@ frame_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=1)
 inference_task: asyncio.Task | None = None
 
 app = Quart(__name__)
+# กำหนดเพดานขนาดไฟล์ที่เซิร์ฟเวอร์ยอมรับ (100 MB)
+app.config["MAX_CONTENT_LENGTH"] = 100 * 1024 * 1024
 camera = cv2.VideoCapture(0)
 
 # ✅ Redirect root ไปหน้า home


### PR DESCRIPTION
## Summary
- limit Quart uploads to 100 MB to support large model and label files

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688d8d180594832ba57dd61baa1c7d6a