### PR TITLE
feat: load saved rois on start and save

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -58,6 +58,7 @@
             socket.onmessage = function(event) {
                 video.src = 'data:image/jpeg;base64,' + event.data;
             };
+            await loadRois(name);
         }
 
         canvas.onmousedown = (e) => {
@@ -108,6 +109,13 @@
             });
         }
 
+        async function loadRois(name) {
+            const res = await fetch('/load_roi/' + encodeURIComponent(name));
+            const data = await res.json();
+            rois = data.rois;
+            drawAllRois();
+        }
+
         function saveAllRois() {
             if (rois.length === 0) {
                 alert("No ROI selected.");
@@ -124,8 +132,7 @@
             .then(res => res.json())
             .then(data => {
                 alert("Saved to: " + data.filename);
-                rois = [];
-                drawAllRois();
+                loadRois(name);
             });
         }
     


### PR DESCRIPTION
## Summary
- add `loadRois` to fetch previously saved ROIs
- load saved ROIs when starting stream
- reload ROIs after saving

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688d9461d848832b9460fb8c903bea26