### PR TITLE
สร้าง rois.json และเพิ่มพาธใน config

### DIFF
--- a/app.py
+++ b/app.py
@@ -106,11 +106,15 @@ async def create_source():
     try:
         await model.save(os.path.join(source_dir, "model.onnx"))
         await label.save(os.path.join(source_dir, "classes.txt"))
+        rois_path = os.path.join(source_dir, "rois.json")
+        with open(rois_path, "w") as f:
+            f.write("[]")
         config = {
             "name": name,
             "source": source,
             "model": "model.onnx",
             "label": "classes.txt",
+            "rois": "rois.json",
         }
         with open(os.path.join(source_dir, "config.json"), "w") as f:
             json.dump(config, f)


### PR DESCRIPTION
## Summary
- สร้างไฟล์ `rois.json` ค่าเริ่มต้นเป็น `[]` เมื่อสร้าง source ใหม่
- เพิ่มฟิลด์ `rois` ใน `config.json` เพื่อชี้ไปยังไฟล์ `rois.json`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688d99136c2c832b9e01999ab579d66d