### PR TITLE
feat: support explicit roi paths

### DIFF
--- a/app.py
+++ b/app.py
@@ -183,11 +183,20 @@ async def source_config():
         cfg = json.load(f)
     return jsonify(cfg)
 
+"""ROI save and load helpers"""
+
 # ✅ บันทึก ROI
 @app.route("/save_roi", methods=["POST"])
 async def save_roi():
     data = await request.get_json()
     rois = data.get("rois", [])
+    path = request.args.get("path", "")
+    if path:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            json.dump(rois, f, indent=2)
+        return jsonify({"status": "saved", "filename": path})
+
     name = data.get("source", "")
     if not name:
         return jsonify({"status": "error", "message": "missing source"}), 400
@@ -214,6 +223,16 @@ async def load_roi(name: str):
     with open(os.path.join(directory, latest_file), "r") as f:
         rois = json.load(f)
     return jsonify({"rois": rois, "filename": latest_file})
+
+# ✅ โหลด ROI ตามพาธที่ระบุใน config
+@app.route("/load_roi_file")
+async def load_roi_file():
+    path = request.args.get("path", "")
+    if not path or not os.path.exists(path):
+        return jsonify({"rois": [], "filename": "None"})
+    with open(path, "r") as f:
+        rois = json.load(f)
+    return jsonify({"rois": rois, "filename": os.path.basename(path)})
 
 # ✅ ส่ง snapshot 1 เฟรม (ใช้ในหน้า inference)
 @app.route("/ws_snapshot")

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -22,6 +22,7 @@
         let drawing = false;
         let startX, startY;
         let rois = [];
+        let roiPath = "";
 
         const video = document.getElementById("video");
         const canvas = document.getElementById("canvas");
@@ -48,6 +49,7 @@
                 return;
             }
             const cfg = await fetch(`/source_config?name=${encodeURIComponent(name)}`).then(r => r.json());
+            roiPath = cfg.rois;
             await fetch("/set_camera", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
@@ -58,7 +60,7 @@
             socket.onmessage = function(event) {
                 video.src = 'data:image/jpeg;base64,' + event.data;
             };
-            await loadRois(name);
+            await loadRois();
         }
 
         canvas.onmousedown = (e) => {
@@ -109,8 +111,13 @@
             });
         }
 
-        async function loadRois(name) {
-            const res = await fetch('/load_roi/' + encodeURIComponent(name));
+        async function loadRois() {
+            if (!roiPath) {
+                rois = [];
+                drawAllRois();
+                return;
+            }
+            const res = await fetch(`/load_roi_file?path=${encodeURIComponent(roiPath)}`);
             const data = await res.json();
             rois = data.rois;
             drawAllRois();
@@ -123,16 +130,15 @@
             }
             if (!confirm("Save all ROIs?")) return;
 
-            const name = document.getElementById("sourceSelect").value;
-            fetch("/save_roi", {
+            fetch(`/save_roi?path=${encodeURIComponent(roiPath)}` , {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ rois: rois, source: name })
+                body: JSON.stringify({ rois: rois })
             })
             .then(res => res.json())
             .then(data => {
                 alert("Saved to: " + data.filename);
-                loadRois(name);
+                loadRois();
             });
         }
     


### PR DESCRIPTION
## Summary
- allow saving ROI to explicit file path
- fetch ROI definitions from path provided in source config

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- Failed: `python - <<'PY'
import asyncio, os, json
from app import app

async def main():
    os.makedirs('sources/test', exist_ok=True)
    cfg_path = 'sources/test/config.json'
    roi_path = 'sources/test/rois.json'
    with open(cfg_path, 'w') as f:
        json.dump({'name': 'test', 'source': 0, 'rois': roi_path}, f)
    with open(roi_path, 'w') as f:
        json.dump([{'x':1,'y':2,'width':3,'height':4}], f)

    client = app.test_client()
    res = await client.get('/source_config?name=test')
    cfg = await res.get_json()
    assert cfg['rois'] == roi_path
    res = await client.get(f'/load_roi_file?path={roi_path}')
    data = await res.get_json()
    assert data['rois'][0]['x'] == 1
    new_rois = [{'x':5,'y':6,'width':7,'height':8}]
    res = await client.post(f'/save_roi?path={roi_path}', json={'rois': new_rois})
    save_res = await res.get_json()
    assert save_res['status'] == 'saved'
    with open(roi_path) as f:
        stored = json.load(f)
    assert stored == new_rois
    print('ok')

asyncio.run(main())
PY`


------
https://chatgpt.com/codex/tasks/task_e_688d995d5760832b963e47784923938c