### PR TITLE
Add description for Create Source on home page

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -56,6 +56,7 @@
     <h2>AI Video Stream Dashboard</h2>
     <p>Welcome! Use the side menu to navigate between features:</p>
     <ul>
+      <li><strong>➕ Create Source</strong> – configure a new video source and upload the corresponding model and label files.</li>
       <li><strong>📐 ROI Selection</strong> – draw Regions of Interest on the live camera stream and save them to a JSON file.</li>
       <li><strong>🤖 Inference</strong> – load saved ROI and run AI model inference on those regions.</li>
     </ul>


### PR DESCRIPTION
## Summary
- Document Create Source feature on home page so all three navigation items are described

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688da0f632b4832b8d20f00c61337d96