### PR TITLE
Add stop stream control

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -10,6 +10,7 @@
 <body>
     <select id="sourceSelect"></select>
     <button onclick="startStream()">Start</button>
+    <button onclick="stopStream()">Stop</button>
     <button onclick="saveAllRois()">Save All</button>
     <br><br>
     <div style="position: relative; display: inline-block;">
@@ -61,6 +62,17 @@
                 video.src = 'data:image/jpeg;base64,' + event.data;
             };
             await loadRois();
+        }
+
+        async function stopStream() {
+            await fetch("/stop_inference", { method: "POST" });
+            if (socket) {
+                socket.close();
+                socket = null;
+            }
+            video.src = "";
+            rois = [];
+            drawAllRois();
         }
 
         canvas.onmousedown = (e) => {


### PR DESCRIPTION
## Summary
- Add Stop button on ROI selection page
- Implement stopStream function to terminate inference, close WebSocket, and clear ROIs

## Testing
- `pip install quart` *(fails: Could not find a version that satisfies the requirement quart)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688da4ea0930832bb296a5010af62094