### PR TITLE
Redraw ROIs after video resize

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -24,16 +24,21 @@
         let startX, startY;
         let rois = [];
         let roiPath = "";
+        let initialized = false;
 
         const video = document.getElementById("video");
         const canvas = document.getElementById("canvas");
         const ctx = canvas.getContext("2d");
 
         video.onload = () => {
-            canvas.width = video.naturalWidth;
-            canvas.height = video.naturalHeight;
-            canvas.style.width = video.naturalWidth + 'px';
-            canvas.style.height = video.naturalHeight + 'px';
+            if (!initialized || canvas.width !== video.naturalWidth || canvas.height !== video.naturalHeight) {
+                canvas.width = video.naturalWidth;
+                canvas.height = video.naturalHeight;
+                canvas.style.width = video.naturalWidth + 'px';
+                canvas.style.height = video.naturalHeight + 'px';
+                initialized = true;
+            }
+            drawAllRois();
         };
 
         async function loadSources() {


### PR DESCRIPTION
## Summary
- reinitialize canvas size only if video dimension changes
- redraw stored ROIs whenever the video loads or the canvas gets resized

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688da8446734832ba94531b3662164fc