### PR TITLE
Handle missing directory in save_roi

### DIFF
--- a/app.py
+++ b/app.py
@@ -268,7 +268,9 @@ async def save_roi():
     rois = data.get("rois", [])
     path = request.args.get("path", "")
     if path:
-        os.makedirs(os.path.dirname(path), exist_ok=True)
+        dir_path = os.path.dirname(path)
+        if dir_path:
+            os.makedirs(dir_path, exist_ok=True)
         with open(path, "w") as f:
             json.dump(rois, f, indent=2)
         return jsonify({"status": "saved", "filename": path})


### PR DESCRIPTION
## Summary
- avoid FileNotFoundError when saving ROI to a filename without a directory

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688da97fd0b4832b867542f0da79b037