### PR TITLE
Allow optional model and label for sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ sources/
     └── rois.json
 ```
 
-เมื่อใช้หน้า **Create Source** (ที่ `/create_source`) ระบบจะรับชื่อ, ค่า source, ไฟล์ model และ label แล้วจะสร้างโฟลเดอร์ใหม่ใน `sources/<name>` พร้อมบันทึกไฟล์และไฟล์ `config.json` ที่เก็บข้อมูล:
+เมื่อใช้หน้า **Create Source** (ที่ `/create_source`) ระบบจะรับชื่อและค่า source พร้อมไฟล์ model และ label (ถ้ามี) แล้วจะสร้างโฟลเดอร์ใหม่ใน `sources/<name>` พร้อมบันทึกไฟล์และไฟล์ `config.json` ที่เก็บข้อมูล:
 
 ```
 {
   "name": "...",
   "source": "...",
-  "model": "model.onnx",
-  "label": "classes.txt",
+  "model": "model.onnx",  // หรือ "" ถ้าไม่ได้อัปโหลด
+  "label": "classes.txt", // หรือ "" ถ้าไม่ได้อัปโหลด
   "rois": "rois.json"
 }
 ```
@@ -31,6 +31,6 @@ sources/
 
 1. เปิด `/create_source` ในเบราว์เซอร์
 2. กรอก `Name` และ `Source`
-3. เลือกไฟล์โมเดล (`model.onnx`) และไฟล์ label (`classes.txt`)
-4. กด **Create** ระบบจะสร้างโฟลเดอร์ใหม่ใน `sources/` พร้อมไฟล์ทั้งหมด
+3. (ไม่บังคับ) เลือกไฟล์โมเดล (`model.onnx`) และไฟล์ label (`classes.txt`)
+4. กด **Create** ระบบจะสร้างโฟลเดอร์ใหม่ใน `sources/` พร้อมไฟล์ที่อัปโหลด
 

--- a/app.py
+++ b/app.py
@@ -140,7 +140,7 @@ async def create_source():
     source = form.get("source", "").strip()
     model = files.get("model")
     label = files.get("label")
-    if not name or not source or model is None or label is None:
+    if not name or not source:
         return jsonify({"status": "error", "message": "missing data"}), 400
 
     source_dir = f"sources/{name}"
@@ -150,18 +150,22 @@ async def create_source():
         return jsonify({"status": "error", "message": "name exists"}), 400
 
     try:
-        await model.save(os.path.join(source_dir, "model.onnx"))
-        await label.save(os.path.join(source_dir, "classes.txt"))
-        rois_path = os.path.join(source_dir, "rois.json")
-        with open(rois_path, "w") as f:
-            f.write("[]")
         config = {
             "name": name,
             "source": source,
-            "model": "model.onnx",
-            "label": "classes.txt",
+            "model": "",
+            "label": "",
             "rois": "rois.json",
         }
+        if model:
+            await model.save(os.path.join(source_dir, "model.onnx"))
+            config["model"] = "model.onnx"
+        if label:
+            await label.save(os.path.join(source_dir, "classes.txt"))
+            config["label"] = "classes.txt"
+        rois_path = os.path.join(source_dir, "rois.json")
+        with open(rois_path, "w") as f:
+            f.write("[]")
         with open(os.path.join(source_dir, "config.json"), "w") as f:
             json.dump(config, f)
     except Exception:

--- a/templates/create_source.html
+++ b/templates/create_source.html
@@ -37,11 +37,11 @@
         </div>
         <div>
             <label for="model">Model:</label>
-            <input type="file" id="model" name="model" required>
+            <input type="file" id="model" name="model">
         </div>
         <div>
             <label for="label">Label:</label>
-            <input type="file" id="label" name="label" required>
+            <input type="file" id="label" name="label">
         </div>
         <button type="submit">Create</button>
     </form>


### PR DESCRIPTION
## Summary
- allow creating a source without model or label
- document optional model/label usage

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688db511b5c0832bbb41f5e57f7a2d2b