### PR TITLE
Add custom ROI processing hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ sources/
     ├── model.onnx
     ├── classes.txt
     ├── config.json
-    └── rois.json
+    ├── rois.json
+    └── custom.py
 ```
 
 เมื่อใช้หน้า **Create Source** (ที่ `/create_source`) ระบบจะรับชื่อและค่า source พร้อมไฟล์ model และ label (ถ้ามี) แล้วจะสร้างโฟลเดอร์ใหม่ใน `sources/<name>` พร้อมบันทึกไฟล์และไฟล์ `config.json` ที่เก็บข้อมูล:
@@ -26,6 +27,7 @@ sources/
 ```
 
 หน้า **ROI** จะอ่านและบันทึก ROI จากไฟล์ `rois.json` ในโฟลเดอร์ของ source นั้น ๆ
+และจะมีไฟล์ `custom.py` สำหรับเขียนฟังก์ชัน `process(img)` เพื่อประมวลผลภาพ ROI เพิ่มเติมได้ตามต้องการ
 
 ## วิธีใช้งานหน้า Create Source
 


### PR DESCRIPTION
## Summary
- load and invoke `custom.py` for each ROI during inference
- generate a `custom.py` stub when creating a new source
- track active source in camera setup and document custom hook

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688dbe069158832bb70fb957c837a758