### PR TITLE
Add camera initialization check for snapshot endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -431,6 +431,8 @@ async def load_roi_file():
 # ✅ ส่ง snapshot 1 เฟรม (ใช้ในหน้า inference)
 @app.route("/ws_snapshot")
 async def ws_snapshot():
+    if camera is None or not camera.isOpened():
+        return "Camera not initialized", 400
     success, frame = camera.read()
     if not success:
         return "Camera error", 500


### PR DESCRIPTION
## Summary
- prevent reading from uninitialized camera in `/ws_snapshot`

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'quart')*

------
https://chatgpt.com/codex/tasks/task_e_688dd36e3070832ba17fb4d0ff1a3094