### PR TITLE
fix botsort tracker import paths

### DIFF
--- a/src/packages/tracks/botsort/tracker/bot_sort.py
+++ b/src/packages/tracks/botsort/tracker/bot_sort.py
@@ -3,10 +3,10 @@ import matplotlib.pyplot as plt
 import numpy as np
 from collections import deque
 
-from packages.botsort.tracker import matching
-from packages.botsort.tracker.gmc import GMC
-from packages.botsort.tracker.basetrack import BaseTrack, TrackState
-from packages.botsort.tracker.kalman_filter import KalmanFilter
+from packages.tracks.botsort.tracker import matching
+from packages.tracks.botsort.tracker.gmc import GMC
+from packages.tracks.botsort.tracker.basetrack import BaseTrack, TrackState
+from packages.tracks.botsort.tracker.kalman_filter import KalmanFilter
 
 # from fast_reid.fast_reid_interfece import FastReIDInterface
 

--- a/src/packages/tracks/botsort/tracker/mc_bot_sort.py
+++ b/src/packages/tracks/botsort/tracker/mc_bot_sort.py
@@ -1,10 +1,10 @@
 import numpy as np
 from collections import deque
 
-from tracks.botsort.tracker import matching
-from tracks.botsort.tracker.gmc import GMC
-from tracks.botsort.tracker.basetrack import BaseTrack, TrackState
-from tracks.botsort.tracker.kalman_filter import KalmanFilter
+from packages.tracks.botsort.tracker import matching
+from packages.tracks.botsort.tracker.gmc import GMC
+from packages.tracks.botsort.tracker.basetrack import BaseTrack, TrackState
+from packages.tracks.botsort.tracker.kalman_filter import KalmanFilter
 # from packages.botsort.fast_reid.fast_reid_interfece import FastReIDInterface
 
 def tlwh_to_xyxy(tlwh):


### PR DESCRIPTION
## Summary
- adjust BotSORT import paths to use `packages.tracks`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e0b4b39b4832b9f505136d2c2e290