### PR TITLE
เพิ่มตัวอย่างแหล่งข้อมูล test_source พร้อม custom process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,7 +207,9 @@ marimo/_lsp/
 __marimo__/
 
 # Ignore local sources
-sources/
+sources/*
+!sources/test_source/
+!sources/test_source/**
 
 # ROI files
 rois_*.json

--- a/sources/.gitignore
+++ b/sources/.gitignore
@@ -1,2 +1,4 @@
 *
 !.gitignore
+!test_source/
+!test_source/**

--- a/sources/test_source/custom.py
+++ b/sources/test_source/custom.py
@@ -1,0 +1,3 @@
+def process(frame):
+    """ตัวอย่างฟังก์ชันประมวลผลเฟรม"""
+    return frame


### PR DESCRIPTION
## สรุป
- เพิ่มโฟลเดอร์ `test_source` ใต้ `sources` พร้อมไฟล์ `custom.py` สำหรับตัวอย่างฟังก์ชัน `process`
- ปรับ `.gitignore` เพื่อไม่ให้มองข้ามโฟลเดอร์ `sources/test_source`

## การทดสอบ
- `pytest` (ไม่มีเทสต์ให้รัน)
- พยายามรัน `python app.py` แต่ล้มเหลวเพราะขาดไลบรารี `libGL.so.1`
- พยายาม `apt-get update` และ `pip install opencv-python-headless` เพื่อแก้ปัญหา แต่ถูกบล็อก (HTTP 403)


------
https://chatgpt.com/codex/tasks/task_e_688e0b4bad48832b824a5caf6b0ea2cd