### PR TITLE
Add pyproject-based packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,10 @@
 - Quart
 - opencv-python
 
-ติดตั้ง dependencies:
+ติดตั้ง dependencies และแพ็กเกจแบบ editable:
 
 ```bash
-pip install -r requirements.txt
-# หรือ
-pip install Quart opencv-python
+pip install -e .
 ```
 
 ## การรันโปรเจ็กต์

--- a/app.py
+++ b/app.py
@@ -6,7 +6,6 @@ import json
 import shutil
 import importlib.util
 import os, sys
-sys.path.insert(0, os.path.abspath("src"))
 from types import ModuleType
 
 frame_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "web_ocrroi"
+version = "0.1.0"
+description = "Quart app for OCR and ROI handling"
+requires-python = ">=3.10"
+dependencies = [
+    "Quart",
+    "opencv-python",
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]


### PR DESCRIPTION
## Summary
- use pyproject.toml with setuptools to expose packages under src
- remove manual sys.path tweaks and note editable install in docs

## Testing
- `python -m py_compile app.py`
- `python -m compileall -f src`
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0)*

------
https://chatgpt.com/codex/tasks/task_e_688e0a5782ac832bba0fe83ebb81d546