### PR TITLE
เพิ่มคำแนะนำการทดสอบใน README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,11 @@ data_sources/
 ## ข้อมูลเพิ่มเติม
 - สร้าง `custom.py` ตามตัวอย่างข้างต้นภายใน `data_sources/<name>/`
 - `config.json` เก็บข้อมูล source, โมเดล และไฟล์ ROI
+
+## การทดสอบ
+ติดตั้ง dependencies แล้วสามารถรันทดสอบได้ด้วย:
+
+```bash
+pytest
+```
+


### PR DESCRIPTION
## Summary
- เพิ่มส่วน **การทดสอบ** ใน README เพื่อบอกวิธีรันทดสอบด้วย `pytest`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ec9fce35c832bae7cd9bffe758bd7