### PR TITLE
ปรับ layout ให้ header และเมนูด้านข้างตรึงตำแหน่ง

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,54 @@
+:root {
+  --header-height: 60px;
+  --sidenav-width: 200px;
+}
+
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  height: var(--header-height);
+  background-color: #111;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  padding-left: 20px;
+  box-sizing: border-box;
+  z-index: 1000;
+}
+
+.sidenav {
+  position: fixed;
+  top: var(--header-height);
+  left: 0;
+  width: var(--sidenav-width);
+  height: calc(100vh - var(--header-height));
+  background-color: #111;
+  padding-top: 20px;
+  box-sizing: border-box;
+}
+
+.sidenav a {
+  padding: 10px 20px;
+  text-decoration: none;
+  font-size: 16px;
+  color: #ddd;
+  display: block;
+}
+
+.sidenav a:hover {
+  background-color: #575757;
+  color: white;
+}
+
+main {
+  margin-top: var(--header-height);
+  margin-left: calc(var(--sidenav-width) + 10px);
+  padding: 20px;
+  box-sizing: border-box;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{% block title %}AI Dashboard{% endblock %}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+  <header>
+    <h1>AI Stream Dashboard</h1>
+  </header>
+  <nav class="sidenav">
+    <a href="/home">🏠 Home</a>
+    <a href="/create_source">➕ Create Source</a>
+    <a href="/roi">📐 ROI Selection</a>
+    <a href="/inference">🤖 Inference</a>
+  </nav>
+  <main>
+    {% block content %}{% endblock %}
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- เพิ่มไฟล์ static/style.css เพื่อจัดตำแหน่ง header และ sidenav แบบ fixed พร้อมพื้นที่ให้ main
- เพิ่ม templates/base.html ลิงก์ไปยัง style.css และประกอบด้วย header, sidenav, main block

## Testing
- `pytest` (ไม่มีการทดสอบให้รัน)


------
https://chatgpt.com/codex/tasks/task_e_688ecd5030c0832b89310f976625ba2e