### PR TITLE
Add fragment endpoints and dynamic content loading

### DIFF
--- a/app.py
+++ b/app.py
@@ -42,6 +42,23 @@ async def roi_page():
 async def inference():
     return await render_template("inference.html")
 
+# ✅ Fragment endpoints สำหรับโหลดคอนเทนต์แบบไม่ใช้ layout
+@app.route("/fragment/home")
+async def fragment_home():
+    return await render_template("fragments/home.html")
+
+@app.route("/fragment/create_source")
+async def fragment_create_source():
+    return await render_template("fragments/create_source.html")
+
+@app.route("/fragment/roi")
+async def fragment_roi():
+    return await render_template("fragments/roi_selection.html")
+
+@app.route("/fragment/inference")
+async def fragment_inference():
+    return await render_template("fragments/inference.html")
+
 
 def load_custom_module(name: str) -> ModuleType | None:
     path = os.path.join("data_sources", name, "custom.py")

--- a/templates/fragments/create_source.html
+++ b/templates/fragments/create_source.html
@@ -1,0 +1,93 @@
+<style>
+    table {
+        border-collapse: collapse;
+        width: 100%;
+        margin-top: 20px;
+    }
+    th, td {
+        border: 1px solid #ccc;
+        padding: 8px;
+    }
+    th {
+        background-color: #f0f0f0;
+    }
+    button.delete {
+        background-color: #e74c3c;
+        color: #fff;
+        border: none;
+        padding: 6px 12px;
+        cursor: pointer;
+    }
+</style>
+<h2>Create Source</h2>
+<form method="POST" action="/create_source" enctype="multipart/form-data">
+    <div>
+        <label for="name">Name:</label>
+        <input type="text" id="name" name="name" required>
+    </div>
+    <div>
+        <label for="source">Source:</label>
+        <input type="text" id="source" name="source" required>
+    </div>
+    <div>
+        <label for="model">Model:</label>
+        <input type="file" id="model" name="model">
+    </div>
+    <div>
+        <label for="label">Label:</label>
+        <input type="file" id="label" name="label">
+    </div>
+    <button type="submit">Create</button>
+</form>
+
+<h3>Source List</h3>
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Source</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody id="source-table-body">
+    </tbody>
+</table>
+
+<script>
+    async function loadSources() {
+        try {
+            const resp = await fetch('/source_list');
+            const data = await resp.json();
+            const tbody = document.getElementById('source-table-body');
+            tbody.innerHTML = '';
+            data.forEach(src => {
+                const tr = document.createElement('tr');
+                const nameTd = document.createElement('td');
+                nameTd.textContent = src.name;
+                const sourceTd = document.createElement('td');
+                sourceTd.textContent = src.source;
+                const actionTd = document.createElement('td');
+                const delBtn = document.createElement('button');
+                delBtn.textContent = 'Delete';
+                delBtn.classList.add('delete');
+                delBtn.addEventListener('click', async () => {
+                    if (confirm(`Delete ${src.name}?`)) {
+                        const res = await fetch(`/delete_source/${encodeURIComponent(src.name)}`, {method: 'DELETE'});
+                        if (res.ok) {
+                            await loadSources();
+                        }
+                    }
+                });
+                actionTd.appendChild(delBtn);
+                tr.appendChild(nameTd);
+                tr.appendChild(sourceTd);
+                tr.appendChild(actionTd);
+                tbody.appendChild(tr);
+            });
+        } catch (err) {
+            console.error('Failed to load sources', err);
+        }
+    }
+
+    loadSources();
+</script>

--- a/templates/fragments/home.html
+++ b/templates/fragments/home.html
@@ -1,0 +1,8 @@
+<h2>AI Video Stream Dashboard</h2>
+<p>Welcome! Use the side menu to navigate between features:</p>
+<ul>
+  <li><strong>➕ Create Source</strong> – configure a new video source and upload the corresponding model and label files.</li>
+  <li><strong>📐 ROI Selection</strong> – draw Regions of Interest on the live camera stream and save them to a JSON file.</li>
+  <li><strong>🤖 Inference</strong> – load saved ROI and run AI model inference on those regions.</li>
+</ul>
+<p>This dashboard is designed to help visualize and interact with AI-powered video processing in real time.</p>

--- a/templates/fragments/inference.html
+++ b/templates/fragments/inference.html
@@ -1,0 +1,120 @@
+<h2>Inference with Saved ROI</h2>
+<select id="sourceSelect"></select>
+<button id="startButton">Start</button>
+<button id="stopButton" disabled>Stop</button>
+<p id="status"></p>
+<div style="position: relative; display: inline-block;">
+    <img id="video" width="640" height="480" />
+</div>
+
+<script>
+    let socket;
+    let rois = [];
+    const video = document.getElementById("video");
+    const startButton = document.getElementById("startButton");
+    const stopButton = document.getElementById("stopButton");
+    const statusEl = document.getElementById("status");
+
+    startButton.onclick = startInference;
+    stopButton.onclick = stopInference;
+
+    async function loadSources() {
+        const res = await fetch("/data_sources");
+        const data = await res.json();
+        const select = document.getElementById("sourceSelect");
+        data.forEach(name => {
+            const opt = document.createElement("option");
+            opt.value = name;
+            opt.textContent = name;
+            select.appendChild(opt);
+        });
+    }
+
+    async function startInference() {
+        const name = document.getElementById("sourceSelect").value;
+        if (!name) {
+            statusEl.innerText = "Select source first";
+            return;
+        }
+        const cfg = await fetch(`/source_config?name=${encodeURIComponent(name)}`).then(r => r.json());
+
+        let roiPath = cfg.rois;
+        if (!roiPath.startsWith('/')) {
+            roiPath = `data_sources/${cfg.name}/${roiPath}`;
+        }
+
+        const camRes = await fetch("/set_camera", {
+            method: "POST",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify(cfg)
+        });
+        if (!camRes.ok) {
+            statusEl.innerText = "Camera error";
+            return;
+        }
+
+        const res = await fetch(`/load_roi_file?path=${encodeURIComponent(roiPath)}`);
+        const data = await res.json();
+        statusEl.innerText = "Loaded: " + data.filename;
+        rois = data.rois;
+
+        const startRes = await fetch("/start_inference", {
+            method: "POST",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify({ rois })
+        });
+        const startData = await startRes.json();
+        if (startData.status === "started" || startData.status === "already_running") {
+            openSocket();
+            setRunningUI();
+        }
+    }
+
+    async function stopInference() {
+        await fetch("/stop_inference", { method: "POST" });
+        if (socket) {
+            socket.close();
+            socket = null;
+        }
+        statusEl.innerText = "Stopped";
+        startButton.innerText = "Resume";
+        startButton.disabled = false;
+        stopButton.disabled = true;
+    }
+
+    function openSocket() {
+        socket = new WebSocket("ws://" + location.host + "/ws");
+        socket.onmessage = function(event) {
+            video.src = 'data:image/jpeg;base64,' + event.data;
+        };
+    }
+
+    async function checkStatus() {
+        const name = document.getElementById("sourceSelect").value;
+        const res = await fetch("/inference_status");
+        const data = await res.json();
+        if (data.running && name) {
+            openSocket();
+            setRunningUI();
+        } else {
+            statusEl.innerText = "Idle";
+            startButton.innerText = "Start";
+            startButton.disabled = false;
+            stopButton.disabled = true;
+        }
+    }
+
+    function setRunningUI() {
+        statusEl.innerText = "Running";
+        startButton.disabled = true;
+        stopButton.disabled = false;
+        startButton.innerText = "Start";
+    }
+
+    (async () => {
+        await loadSources();
+        await checkStatus();
+    })();
+
+    // ไม่มีการวาด ROI ในฝั่งเบราว์เซอร์อีกต่อไป
+</script>

--- a/templates/fragments/roi_selection.html
+++ b/templates/fragments/roi_selection.html
@@ -1,0 +1,202 @@
+    <style>
+        #video { border: 1px solid black; position: relative; }
+        #canvas { position: absolute; left: 0; top: 0; }
+    </style>
+    <select id="sourceSelect"></select>
+    <button onclick="startStream()">Start</button>
+    <button onclick="stopStream()">Stop</button>
+    <button onclick="saveAllRois()">Save All</button>
+    <button onclick="clearAllRois()">Clear All</button>
+    <br><br>
+    <div style="position: relative; display: inline-block;">
+        <img id="video" />
+        <canvas id="canvas"></canvas>
+    </div>
+
+    <script>
+        let socket;
+        let drawing = false;
+        let startX, startY;
+        let rois = [];
+        let currentRoi = null;
+        let currentSource = "";
+        let initialized = false;
+
+        const video = document.getElementById("video");
+        const canvas = document.getElementById("canvas");
+        const ctx = canvas.getContext("2d");
+
+        video.onload = () => {
+            if (!initialized || canvas.width !== video.naturalWidth || canvas.height !== video.naturalHeight) {
+                canvas.width = video.naturalWidth;
+                canvas.height = video.naturalHeight;
+                canvas.style.width = video.naturalWidth + 'px';
+                canvas.style.height = video.naturalHeight + 'px';
+                initialized = true;
+            }
+            drawAllRois();
+        };
+
+        async function loadSources() {
+            const res = await fetch("/data_sources");
+            const data = await res.json();
+            const select = document.getElementById("sourceSelect");
+            data.forEach(name => {
+                const opt = document.createElement("option");
+                opt.value = name;
+                opt.textContent = name;
+                select.appendChild(opt);
+            });
+        }
+
+        loadSources();
+
+        async function startStream() {
+            const name = document.getElementById("sourceSelect").value;
+            if (!name) {
+                alert("Select source first");
+                return;
+            }
+            currentSource = name;
+            const cfg = await fetch(`/source_config?name=${encodeURIComponent(name)}`).then(r => r.json());
+            await fetch("/set_camera", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ source: cfg.source })
+            });
+            await fetch("/start_roi_stream", { method: "POST" });
+            socket = new WebSocket("ws://" + location.host + "/ws_roi");
+            socket.onmessage = function(event) {
+                video.src = 'data:image/jpeg;base64,' + event.data;
+            };
+            await loadRois();
+        }
+
+        async function stopStream() {
+
+            if (socket) {
+                socket.close();
+                socket = null;
+            }
+
+            await fetch("/stop_roi_stream", { method: "POST" });
+
+        }
+
+        canvas.onmousedown = (e) => {
+            drawing = true;
+            const rect = canvas.getBoundingClientRect();
+            const scaleX = canvas.width / rect.width;
+            const scaleY = canvas.height / rect.height;
+            startX = (e.clientX - rect.left) * scaleX;
+            startY = (e.clientY - rect.top) * scaleY;
+            currentRoi = null;
+        };
+
+        canvas.onmouseup = (e) => {
+            if (!drawing) return;
+            drawing = false;
+            const rect = canvas.getBoundingClientRect();
+            const scaleX = canvas.width / rect.width;
+            const scaleY = canvas.height / rect.height;
+            const endX = (e.clientX - rect.left) * scaleX;
+            const endY = (e.clientY - rect.top) * scaleY;
+            currentRoi = {
+                x: Math.min(startX, endX),
+                y: Math.min(startY, endY),
+                width: Math.abs(endX - startX),
+                height: Math.abs(endY - startY)
+            };
+            rois.push(currentRoi);
+            currentRoi = null;
+            drawAllRois();
+        };
+
+        canvas.onmousemove = (e) => {
+            if (!drawing) return;
+            const rect = canvas.getBoundingClientRect();
+            const scaleX = canvas.width / rect.width;
+            const scaleY = canvas.height / rect.height;
+            const currX = (e.clientX - rect.left) * scaleX;
+            const currY = (e.clientY - rect.top) * scaleY;
+            currentRoi = {
+                x: Math.min(startX, currX),
+                y: Math.min(startY, currY),
+                width: Math.abs(currX - startX),
+                height: Math.abs(currY - startY)
+            };
+            drawAllRois();
+        };
+
+        function drawAllRois() {
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+            rois.forEach(r => {
+                ctx.beginPath();
+                ctx.rect(r.x, r.y, r.width, r.height);
+                ctx.strokeStyle = 'blue';
+                ctx.lineWidth = 2;
+                ctx.stroke();
+            });
+            if (currentRoi) {
+                ctx.beginPath();
+                ctx.rect(currentRoi.x, currentRoi.y, currentRoi.width, currentRoi.height);
+                ctx.strokeStyle = 'red';
+                ctx.lineWidth = 2;
+                ctx.stroke();
+            }
+        }
+
+        async function loadRois() {
+            if (!currentSource) {
+                rois = [];
+                drawAllRois();
+                return;
+            }
+            const res = await fetch(`/load_roi/${encodeURIComponent(currentSource)}`);
+            const data = await res.json();
+            rois = data.rois;
+            drawAllRois();
+        }
+
+        function saveAllRois() {
+            if (rois.length === 0) {
+                alert("No ROI selected.");
+                return;
+            }
+            if (!confirm("Save all ROIs?")) return;
+
+            fetch(`/save_roi`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ rois: rois, source: currentSource })
+            })
+            .then(res => res.json())
+            .then(data => {
+                alert("Saved to: " + data.filename);
+                loadRois();
+            });
+        }
+    
+        function clearAllRois() {
+            if (rois.length === 0) {
+                alert("No ROI to clear.");
+                return;
+            }
+            if (!confirm("Clear all ROIs?")) return;
+
+            rois = [];
+            drawAllRois();
+
+            fetch(`/save_roi`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ rois: rois, source: currentSource })
+            })
+            .then(res => res.json())
+            .then(data => {
+                alert("Cleared. Saved to: " + data.filename);
+                loadRois();
+            });
+        }
+
+    </script>

--- a/templates/home.html
+++ b/templates/home.html
@@ -35,33 +35,46 @@
       margin-left: 210px;
       padding: 20px;
     }
-
-    h2 {
-      margin-top: 0;
-    }
   </style>
 </head>
 <body>
 
-  <!-- Side Menu -->
   <div class="sidenav">
-    <a href="/home">🏠 Home</a>
-    <a href="/create_source">➕ Create Source</a>
-    <a href="/roi">📐 ROI Selection</a>
-    <a href="/inference">🤖 Inference</a>
+    <a href="#" data-fragment="home">🏠 Home</a>
+    <a href="#" data-fragment="create_source">➕ Create Source</a>
+    <a href="#" data-fragment="roi">📐 ROI Selection</a>
+    <a href="#" data-fragment="inference">🤖 Inference</a>
   </div>
 
-  <!-- Main Content -->
-  <div class="main">
-    <h2>AI Video Stream Dashboard</h2>
-    <p>Welcome! Use the side menu to navigate between features:</p>
-    <ul>
-      <li><strong>➕ Create Source</strong> – configure a new video source and upload the corresponding model and label files.</li>
-      <li><strong>📐 ROI Selection</strong> – draw Regions of Interest on the live camera stream and save them to a JSON file.</li>
-      <li><strong>🤖 Inference</strong> – load saved ROI and run AI model inference on those regions.</li>
-    </ul>
-    <p>This dashboard is designed to help visualize and interact with AI-powered video processing in real time.</p>
-  </div>
+  <div class="main" id="content"></div>
 
+  <script>
+    async function loadFragment(name) {
+      const res = await fetch(`/fragment/${name}`);
+      const html = await res.text();
+      const content = document.getElementById('content');
+      content.innerHTML = html;
+      content.querySelectorAll('script').forEach(oldScript => {
+        const newScript = document.createElement('script');
+        if (oldScript.src) {
+          newScript.src = oldScript.src;
+        } else {
+          newScript.textContent = oldScript.textContent;
+        }
+        document.body.appendChild(newScript);
+        oldScript.remove();
+      });
+    }
+
+    document.querySelectorAll('.sidenav a').forEach(a => {
+      a.addEventListener('click', (e) => {
+        e.preventDefault();
+        const frag = a.dataset.fragment;
+        loadFragment(frag);
+      });
+    });
+
+    loadFragment('home');
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `/fragment/*` routes for home, source creation, ROI selection and inference
- convert home page to load content fragments via JavaScript
- add fragment templates for individual sections

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ecd5ac3b4832b8025670ab5d698e2