### PR TITLE
docs: quote install paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,19 @@
 ติดตั้งแพ็กเกจและ dependencies ด้วย `pip`:
 
 ```bash
-pip install .
+pip install "."
 ```
 
 หากต้องการ dependencies เพิ่มเติม เช่น `onnxruntime`, `requests`, `tensorflow`, `torch` สามารถติดตั้งผ่าน extras ได้:
 
 ```bash
-pip install .[extras]
+pip install ".[extras]"
 ```
 
 หรือหากต้องการติดตั้งแบบ editable:
 
 ```bash
-pip install -e .
+pip install -e "."
 ```
 
 ## การรันโปรเจ็กต์


### PR DESCRIPTION
## Summary
- quote install paths in README to prevent path misinterpretation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ed71a7f48832b9e6ce31a4c85b94f