### PR TITLE
docs: add venv setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,27 @@
 - `torch` – สำหรับฟังก์ชันที่ใช้ PyTorch
 
 ## การติดตั้ง
-ติดตั้งแพ็กเกจและ dependencies ด้วย `pip`:
+แนะนำให้สร้าง virtual environment ก่อน:
+
+```bash
+python -m venv .venv
+```
+
+หลังจากสร้างแล้ว ให้ activate environment:
+
+- **Linux/macOS**
+
+  ```bash
+  source .venv/bin/activate
+  ```
+
+- **Windows**
+
+  ```powershell
+  .venv\\Scripts\\activate
+  ```
+
+เมื่อ environment ถูก activate แล้วจึงติดตั้งแพ็กเกจและ dependencies ด้วย `pip`:
 
 ```bash
 pip install "."


### PR DESCRIPTION
## Summary
- add virtual environment creation and activation steps in installation section
- clarify that dependencies should be installed after activating the venv

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ed9d0a114832b9b61604c78364905