### PR TITLE
Use absolute data source path and load names from config

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ import shutil
 import importlib.util
 import os, sys
 from types import ModuleType
+from pathlib import Path
 
 frame_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=1)
 inference_task: asyncio.Task | None = None
@@ -320,8 +321,9 @@ async def inference_status():
 
 @app.route("/data_sources")
 async def list_sources():
+    base_dir = Path(__file__).resolve().parent / "data_sources"
     try:
-        names = [d for d in os.listdir("data_sources") if os.path.isdir(os.path.join("data_sources", d))]
+        names = [d.name for d in base_dir.iterdir() if d.is_dir()]
     except FileNotFoundError:
         names = []
     return jsonify(names)

--- a/templates/fragments/inference.html
+++ b/templates/fragments/inference.html
@@ -18,17 +18,17 @@
     startButton.onclick = startInference;
     stopButton.onclick = stopInference;
 
-    async function loadSources() {
-        const res = await fetch("/data_sources");
-        const data = await res.json();
-        const select = document.getElementById("sourceSelect");
-        data.forEach(name => {
-            const opt = document.createElement("option");
-            opt.value = name;
-            opt.textContent = name;
-            select.appendChild(opt);
-        });
-    }
+      async function loadSources() {
+          const res = await fetch("/source_list");
+          const data = await res.json();
+          const select = document.getElementById("sourceSelect");
+          data.forEach(item => {
+              const opt = document.createElement("option");
+              opt.value = item.name;
+              opt.textContent = item.name;
+              select.appendChild(opt);
+          });
+      }
 
     async function startInference() {
         const name = document.getElementById("sourceSelect").value;

--- a/templates/fragments/roi_selection.html
+++ b/templates/fragments/roi_selection.html
@@ -38,13 +38,13 @@
         };
 
         async function loadSources() {
-            const res = await fetch("/data_sources");
+            const res = await fetch("/source_list");
             const data = await res.json();
             const select = document.getElementById("sourceSelect");
-            data.forEach(name => {
+            data.forEach(item => {
                 const opt = document.createElement("option");
-                opt.value = name;
-                opt.textContent = name;
+                opt.value = item.name;
+                opt.textContent = item.name;
                 select.appendChild(opt);
             });
         }

--- a/templates/inference.html
+++ b/templates/inference.html
@@ -21,18 +21,18 @@
     startButton.onclick = startInference;
     stopButton.onclick = stopInference;
 
-    async function loadSources() {
-        const res = await fetch("/data_sources");
-        const data = await res.json();
-        const select = document.getElementById("sourceSelect");
-        select.innerHTML = '';
-        data.forEach(name => {
-            const opt = document.createElement("option");
-            opt.value = name;
-            opt.textContent = name;
-            select.appendChild(opt);
-        });
-    }
+      async function loadSources() {
+          const res = await fetch("/source_list");
+          const data = await res.json();
+          const select = document.getElementById("sourceSelect");
+          select.innerHTML = '';
+          data.forEach(item => {
+              const opt = document.createElement("option");
+              opt.value = item.name;
+              opt.textContent = item.name;
+              select.appendChild(opt);
+          });
+      }
 
 
     async function startInference() {

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -42,19 +42,19 @@
         drawAllRois();
     };
 
-    async function loadSources() {
-        const res = await fetch("/data_sources");
-        const data = await res.json();
-        const select = document.getElementById("sourceSelect");
-        select.innerHTML = '';
+      async function loadSources() {
+          const res = await fetch("/source_list");
+          const data = await res.json();
+          const select = document.getElementById("sourceSelect");
+          select.innerHTML = '';
 
-        data.forEach(name => {
-            const opt = document.createElement("option");
-            opt.value = name;
-            opt.textContent = name;
-            select.appendChild(opt);
-        });
-    }
+          data.forEach(item => {
+              const opt = document.createElement("option");
+              opt.value = item.name;
+              opt.textContent = item.name;
+              select.appendChild(opt);
+          });
+      }
 
     loadSources();
 


### PR DESCRIPTION
## Summary
- use absolute path for `data_sources`
- fetch `/source_list` on ROI and inference pages

## Testing
- `python -m py_compile app.py && pytest`


------
https://chatgpt.com/codex/tasks/task_e_688edd5a3678832b8579d75e44de4b8c