### PR TITLE
Refactor ROI control buttons

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -8,10 +8,10 @@
 </style>
 
 <select id="sourceSelect"></select>
-<button onclick="startStream()">Start</button>
-<button onclick="stopStream()">Stop</button>
-<button onclick="saveAllRois()">Save All</button>
-<button onclick="clearAllRois()">Clear All</button>
+<button id="startBtn">Start</button>
+<button id="stopBtn">Stop</button>
+<button id="saveBtn">Save All</button>
+<button id="clearBtn">Clear All</button>
 <br><br>
 <div style="position: relative; display: inline-block;">
     <img id="video" />
@@ -203,6 +203,11 @@
                 loadRois();
             });
         }
+
+        document.getElementById('startBtn').addEventListener('click', startStream);
+        document.getElementById('stopBtn').addEventListener('click', stopStream);
+        document.getElementById('saveBtn').addEventListener('click', saveAllRois);
+        document.getElementById('clearBtn').addEventListener('click', clearAllRois);
 
         window.startStream = startStream;
         window.stopStream = stopStream;


### PR DESCRIPTION
## Summary
- replace inline ROI buttons with IDs
- attach event listeners inside IIFE for start/stop/save/clear actions

## Testing
- `pytest`
- `python - <<'PY' from app import app` (fails: ModuleNotFoundError: No module named 'quart')


------
https://chatgpt.com/codex/tasks/task_e_688ee5203998832b9a1fef687e3f90d2