### PR TITLE
Add cleanup for GMC tracker

### DIFF
--- a/src/packages/tracks/botsort/tracker/bot_sort.py
+++ b/src/packages/tracks/botsort/tracker/bot_sort.py
@@ -244,6 +244,10 @@ class BoTSORT(object):
 
         self.gmc = GMC(method=args.cmc_method, verbose=[args.name, args.ablation])
 
+    def __del__(self):
+        if hasattr(self, 'gmc'):
+            self.gmc.cleanup()
+
     def update(self, output_results, img):
         self.frame_id += 1
         activated_starcks = []

--- a/src/packages/tracks/botsort/tracker/gmc.py
+++ b/src/packages/tracks/botsort/tracker/gmc.py
@@ -11,6 +11,7 @@ class GMC:
 
         self.method = method
         self.downscale = max(1, int(downscale))
+        self.gmcFile = None
 
         if self.method == 'orb':
             self.detector = cv2.FastFeatureDetector_create(20)
@@ -314,3 +315,11 @@ class GMC:
         H[1, 2] = float(tokens[6])
 
         return H
+
+    def cleanup(self):
+        if self.gmcFile is not None and not self.gmcFile.closed:
+            self.gmcFile.close()
+            self.gmcFile = None
+
+    def __del__(self):
+        self.cleanup()

--- a/src/packages/tracks/botsort/tracker/mc_bot_sort.py
+++ b/src/packages/tracks/botsort/tracker/mc_bot_sort.py
@@ -279,6 +279,10 @@ class BoTSORT(object):
 
         self.gmc = GMC(method=args.cmc_method, verbose=[args.name, args.ablation])
 
+    def __del__(self):
+        if hasattr(self, 'gmc'):
+            self.gmc.cleanup()
+
     def update(self, boxes, scores, classes, img):
         self.frame_id += 1
         activated_starcks = []


### PR DESCRIPTION
## Summary
- add cleanup method in GMC to close opened file handles
- ensure BoTSORT trackers call cleanup when destroyed

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688eef355b2c832b8d0527740b5be049