### PR TITLE
ลบการนำเข้า matplotlib ที่ไม่ได้ใช้งาน

### DIFF
--- a/src/packages/tracks/botsort/tracker/bot_sort.py
+++ b/src/packages/tracks/botsort/tracker/bot_sort.py
@@ -1,5 +1,4 @@
 import cv2
-import matplotlib.pyplot as plt
 import numpy as np
 from collections import deque
 

--- a/src/packages/tracks/botsort/tracker/gmc.py
+++ b/src/packages/tracks/botsort/tracker/gmc.py
@@ -1,5 +1,4 @@
 import cv2
-# import matplotlib.pyplot as plt
 import numpy as np
 import copy
 import time
@@ -214,9 +213,6 @@ class GMC:
                 matches_img = cv2.circle(matches_img, prev_pt, 2, tuple(color), -1)
                 matches_img = cv2.circle(matches_img, curr_pt, 2, tuple(color), -1)
 
-            # plt.figure()
-            # plt.imshow(matches_img)
-            # plt.show()
 
         # Find rigid matrix
         if (np.size(prevPoints, 0) > 4) and (np.size(prevPoints, 0) == np.size(prevPoints, 0)):


### PR DESCRIPTION
## Summary
- ลบการนำเข้า `matplotlib` ที่ไม่จำเป็นในส่วนติดตามวัตถุ (BOT-SORT และ GMC)
- ล้างโค้ดดีบั๊กที่เรียกใช้ `plt` ใน `GMC`

## Testing
- `pytest` (ไม่พบการทดสอบ)


------
https://chatgpt.com/codex/tasks/task_e_688eef40154c832b819704a9ee10edcf