### PR TITLE
ใช้ asyncio.to_thread ใน loop อ่านกล้อง

### DIFF
--- a/app.py
+++ b/app.py
@@ -80,7 +80,7 @@ async def run_inference_loop():
         if camera is None:
             await asyncio.sleep(0.1)
             continue
-        success, frame = camera.read()
+        success, frame = await asyncio.to_thread(camera.read)
         if not success:
             await asyncio.sleep(0.1)
             continue
@@ -127,7 +127,7 @@ async def run_roi_loop():
         if camera is None:
             await asyncio.sleep(0.1)
             continue
-        success, frame = camera.read()
+        success, frame = await asyncio.to_thread(camera.read)
         if not success:
             await asyncio.sleep(0.1)
             continue

--- a/tests/test_event_loop.py
+++ b/tests/test_event_loop.py
@@ -1,0 +1,107 @@
+import asyncio
+import contextlib
+import time
+
+import sys
+import types
+
+# สร้างโมดูล quart จำลองเพื่อหลีกเลี่ยงการติดตั้งจริง
+quart_stub = types.ModuleType("quart")
+
+
+class DummyQuart:
+    def __init__(self, name):
+        self.config = {}
+
+    def route(self, *args, **kwargs):
+        def decorator(f):
+            return f
+        return decorator
+
+    def websocket(self, *args, **kwargs):
+        def decorator(f):
+            return f
+        return decorator
+
+
+quart_stub.Quart = DummyQuart
+quart_stub.render_template = lambda *a, **k: None
+quart_stub.websocket = lambda *a, **k: None
+quart_stub.request = None
+quart_stub.jsonify = lambda *a, **k: None
+quart_stub.send_file = lambda *a, **k: None
+quart_stub.redirect = lambda *a, **k: None
+
+sys.modules["quart"] = quart_stub
+
+cv2_stub = types.ModuleType("cv2")
+
+
+class DummyVideoCapture:
+    def __init__(self, *a, **k):
+        pass
+
+    def isOpened(self):
+        return True
+
+    def read(self):
+        return True, b"frame"
+
+    def release(self):
+        pass
+
+
+cv2_stub.VideoCapture = DummyVideoCapture
+cv2_stub.imencode = lambda *a, **k: (True, b"data")
+cv2_stub.rectangle = lambda *a, **k: None
+cv2_stub.putText = lambda *a, **k: None
+
+sys.modules["cv2"] = cv2_stub
+
+import app
+
+
+class DummyCamera:
+    def __init__(self):
+        self.frames_read = 0
+
+    def read(self):
+        self.frames_read += 1
+        # จำลองการบล็อก IO หรือการคำนวณที่ใช้เวลานาน
+        time.sleep(0.005)
+        return True, b"frame"
+
+
+async def ticker(duration: float = 0.5, interval: float = 0.01) -> int:
+    count = 0
+    end = time.monotonic() + duration
+    while time.monotonic() < end:
+        count += 1
+        await asyncio.sleep(interval)
+    return count
+
+
+def test_event_loop_responsive():
+    async def main():
+        app.camera = DummyCamera()
+        app.inference_rois = []
+        app.active_source = ""
+        app.cv2.imencode = lambda ext, frame: (True, b"data")
+
+        loop_task = asyncio.create_task(app.run_inference_loop())
+        tick_task = asyncio.create_task(ticker())
+
+        ticks = await tick_task
+        loop_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await loop_task
+
+        frames = app.camera.frames_read
+        app.camera = None
+        return ticks, frames
+
+    ticks, frames = asyncio.run(main())
+    # ยืนยันว่า event loop ยังคง responsive
+    assert ticks > 20
+    # ยืนยันว่ามีการอ่านเฟรมจำนวนมาก
+    assert frames >= 9


### PR DESCRIPTION
## สรุป
- เปลี่ยนให้ `run_inference_loop` และ `run_roi_loop` อ่านเฟรมผ่าน `await asyncio.to_thread(camera.read)` เพื่อไม่บล็อก event loop
- เพิ่มการทดสอบ event loop ด้วยกล้องจำลองเพื่อยืนยันว่ายังคง responsive เมื่อประมวลผลหลายเฟรม

## การทดสอบ
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eef5a4180832b8bdd9127e2bd136c