### PR TITLE
ปรับ home.html ให้ใช้ style.css และเพิ่ม header

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -2,42 +2,13 @@
 <html>
 <head>
   <title>AI Stream Dashboard</title>
-  <style>
-    body {
-      margin: 0;
-      font-family: Arial, sans-serif;
-    }
-
-    .sidenav {
-      height: 100vh;
-      width: 200px;
-      position: fixed;
-      left: 0;
-      top: 0;
-      background-color: #111;
-      padding-top: 20px;
-    }
-
-    .sidenav a {
-      padding: 10px 20px;
-      text-decoration: none;
-      font-size: 16px;
-      color: #ddd;
-      display: block;
-    }
-
-    .sidenav a:hover {
-      background-color: #575757;
-      color: white;
-    }
-
-    .main {
-      margin-left: 210px;
-      padding: 20px;
-    }
-  </style>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
+  <header>
+    <img src="{{ url_for('static', filename='images/logo.jpg') }}" alt="Logo">
+    <h1>AI Stream Dashboard</h1>
+  </header>
 
   <div class="sidenav">
     <a href="#" data-fragment="home">🏠 Home</a>
@@ -46,7 +17,7 @@
     <a href="#" data-fragment="inference">🤖 Inference</a>
   </div>
 
-  <div class="main" id="content"></div>
+  <main id="content"></main>
 
   <script>
     async function loadFragment(name) {


### PR DESCRIPTION
## สรุป
- ย้ายสไตล์ของหน้า Home ไปยังไฟล์ `style.css` และเพิ่ม `<link>` สำหรับโหลดสไตล์
- เพิ่มส่วน `<header>` ที่มีโลโก้และชื่อแอปเพื่อให้สอดคล้องกับ layout หลัก

## การทดสอบ
- `PYTHONPATH=$PWD pytest -q`
- ตรวจสอบด้วยสคริปต์ว่าไฟล์ HTML มี `<link>` ไปยัง `style.css`, `<header>`, `<h1>` และ `<img>` โลโก้
- พยายามติดตั้ง `quart` เพื่อเปิดหน้า `/home` แต่ไม่สามารถเชื่อมต่อกับ proxy ได้


------
https://chatgpt.com/codex/tasks/task_e_688f0000ca58832ba4029e93aa44b351