### PR TITLE
ปรับสไตล์ header และขนาดโลโก้

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -24,9 +24,16 @@ header {
     z-index: 1000;
 }
 
+header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
 .logo {
-    height: 40px;
     margin-left: auto;
+    max-height: 100%;
+    width: auto;
+    object-fit: contain;
 }
 
 .sidenav {


### PR DESCRIPTION
## สรุป
- ลดช่องว่างหัวข้อด้วยกฎ `header h1`
- จำกัดขนาดโลโก้ไม่ให้ล้นด้วย `max-height`, `width: auto` และ `object-fit`

## การทดสอบ
- `pip install -e .` (ล้มเหลว: 403 Proxy Forbidden)
- `pytest` (ล้มเหลว: ModuleNotFoundError: No module named 'app')
- `python app.py` (ล้มเหลว: ModuleNotFoundError: No module named 'quart')

------
https://chatgpt.com/codex/tasks/task_e_688f03778474832b9f19edddee895dea