### PR TITLE
refactor: ปรับ layout หลักให้ใช้ flex

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -6,6 +6,7 @@
 body {
   margin: 0;
   font-family: Arial, sans-serif;
+  display: flex;
 }
 
 header {
@@ -30,14 +31,13 @@ header {
 }
 
 .sidenav {
-  position: fixed;
-  top: var(--header-height);
-  left: 0;
   width: var(--sidenav-width);
   height: calc(100vh - var(--header-height));
   background-color: #111;
   padding-top: 20px;
   box-sizing: border-box;
+  margin-top: var(--header-height);
+  transition: width 0.3s ease;
 }
 
 .sidenav a {
@@ -55,7 +55,9 @@ header {
 
 main {
   margin-top: var(--header-height);
-  margin-left: calc(var(--sidenav-width) + 10px);
+  flex: 1;
+  margin-left: 0;
   padding: 20px;
   box-sizing: border-box;
+  transition: margin-left 0.3s ease;
 }


### PR DESCRIPTION
## สรุป
- ปรับ body เป็น flex container เพื่อจัดวาง sidenav และ main
- ตั้งค่า main ให้กินพื้นที่ที่เหลืออัตโนมัติ และเพิ่ม transition เพื่อรองรับเมนูยุบ/ขยาย
- เพิ่ม transition ให้ sidenav เพื่อให้การยุบ/ขยายเมนูนุ่มนวล

## การทดสอบ
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f037ed8b0832bbbddf80618caf621