### PR TITLE
ปรับความสูง header และจำกัดโลโก้ให้พอดี

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,5 +1,5 @@
 :root {
-  --header-height: 60px;
+  --header-height: 80px;
   --sidenav-width: 200px;
 }
 
@@ -32,7 +32,7 @@ header h1 {
 
 .logo {
     margin-left: auto;
-    max-height: 100%;
+    max-height: calc(var(--header-height) - 20px);
     width: auto;
     object-fit: contain;
 }
@@ -45,7 +45,7 @@ header h1 {
   box-sizing: border-box;
   margin-top: var(--header-height);
   transition: width 0.3s ease;
-
+}
 
 .sidenav a {
   padding: 10px 20px;


### PR DESCRIPTION
## สรุป
- เพิ่มตัวแปร `--header-height` เป็น 80px เพื่อให้พื้นที่ส่วนหัวมากขึ้น
- จำกัดความสูงโลโก้ไม่ให้เกิน `calc(var(--header-height) - 20px)` และปิดบล็อก `.sidenav` ที่ตกหล่น

## การทดสอบ
- `PYTHONPATH=. pytest tests/test_event_loop.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f2722e404832bb13a00b56ed52929