### PR TITLE
Increase header and logo dimensions

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,5 +1,5 @@
 :root {
-  --header-height: 80px;
+  --header-height: 120px;
   --sidenav-width: 200px;
 }
 
@@ -32,7 +32,7 @@ header h1 {
 
 .logo {
     margin-left: auto;
-    max-height: calc(var(--header-height) - 20px);
+    height: 100px;
     width: auto;
     object-fit: contain;
 }

--- a/templates/home.html
+++ b/templates/home.html
@@ -6,8 +6,8 @@
 </head>
 <body>
   <header>
-    <img src="{{ url_for('static', filename='images/logo.jpg') }}" alt="Logo">
     <h1>AI Stream Dashboard</h1>
+    <img src="{{ url_for('static', filename='images/logo.jpg') }}" class="logo" alt="Logo">
   </header>
 
   <div class="sidenav">


### PR DESCRIPTION
## Summary
- increase header height to 120px and set logo height to 100px with auto width
- apply updated logo styling in the home template

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f28ac9a80832b92c06d995b39afa4