### PR TITLE
Adjust header height and align logo left

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,5 +1,5 @@
 :root {
-  --header-height: 120px;
+  --header-height: 170px;
   --sidenav-width: 200px;
 }
 
@@ -18,7 +18,8 @@ header {
   color: #fff;
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-start;
+    gap: 20px;
     padding-left: 20px;
     padding-right: 20px;
     box-sizing: border-box;
@@ -31,8 +32,7 @@ header h1 {
 }
 
 .logo {
-    margin-left: auto;
-    height: 100px;
+    height: calc(var(--header-height) - 20px);
     width: auto;
     object-fit: contain;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,8 +6,8 @@
 </head>
 <body>
   <header>
-    <h1>AI Stream Dashboard</h1>
     <img src="{{ url_for('static', filename='images/logo.jpg') }}" class="logo" alt="logo">
+    <h1>AI Stream Dashboard</h1>
   </header>
   <div class="sidenav">
 


### PR DESCRIPTION
## Summary
- increase header height to 170px and left-align logo

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f2a988f6c832b90120a31781e04fa