### PR TITLE
feat: adjust header spacing

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -17,10 +17,9 @@ header {
   background-color: #111;
   color: #fff;
     display: flex;
-    align-items: center;
+    align-items: flex-end;
     justify-content: flex-start;
-    gap: 20px;
-    padding-left: 20px;
+    padding-left: 0;
     padding-right: 20px;
     box-sizing: border-box;
     z-index: 1000;
@@ -35,6 +34,7 @@ header h1 {
     height: calc(var(--header-height) - 20px);
     width: auto;
     object-fit: contain;
+    margin-right: 10px;
 }
 
 .sidenav {


### PR DESCRIPTION
## Summary
- align header elements to left edge by removing left padding
- add margin to logo for controlled distance from title

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_688f2e66a424832ba79a42d512455f67