### PR TITLE
ปรับธีมเว็บเป็นโทนสีขาว-ฟ้าอ่อน

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -7,6 +7,7 @@ body {
   margin: 0;
   font-family: Arial, sans-serif;
   display: flex;
+  background-color: #ffffff;
 }
 
 header {
@@ -14,8 +15,8 @@ header {
   top: 0;
   width: 100%;
   height: var(--header-height);
-  background-color: #111;
-  color: #fff;
+  background-color: #e6f2ff;
+  color: #003366;
     display: flex;
     align-items: center;
     justify-content: flex-start;
@@ -40,7 +41,7 @@ header h1 {
 .sidenav {
   width: var(--sidenav-width);
   height: calc(100vh - var(--header-height));
-  background-color: #111;
+  background-color: #e6f2ff;
   padding-top: 20px;
   box-sizing: border-box;
   margin-top: var(--header-height);
@@ -51,18 +52,18 @@ header h1 {
   padding: 10px 20px;
   text-decoration: none;
   font-size: 16px;
-  color: #ddd;
+  color: #003366;
   display: block;
 }
 
 .sidenav a:hover {
-  background-color: #575757;
-  color: white;
+  background-color: #d0e7ff;
+  color: #003366;
 }
 
 .sidenav a.active {
-  background-color: #04AA6D;
-  color: white;
+  background-color: #b2d4ff;
+  color: #003366;
 }
 
 main {
@@ -72,6 +73,7 @@ main {
   padding: 20px;
   box-sizing: border-box;
   transition: margin-left 0.3s ease;
+  background-color: #ffffff;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- ปรับพื้นหลังหน้าและพื้นที่เนื้อหาเป็นสีขาว
- เปลี่ยนสี header และเมนูด้านข้างเป็นฟ้าอ่อน พร้อมปรับสีลิงก์ให้เข้าธีม

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f32d5f8f4832ba318cb26f668eb8a