### PR TITLE
ปรับตำแหน่งโลโก้และชื่อใน header ไปด้านขวา

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -19,9 +19,9 @@ header {
   color: #003366;
     display: flex;
     align-items: center;
-    justify-content: flex-start;
-    padding-left: 0;
-    padding-right: 20px;
+    justify-content: flex-end;
+    padding-left: 20px;
+    padding-right: 0;
     box-sizing: border-box;
     z-index: 1000;
 }
@@ -35,7 +35,7 @@ header h1 {
     height: calc(var(--header-height) - 20px);
     width: auto;
     object-fit: contain;
-    margin-right: 10px;
+    margin-right: 5px;
 }
 
 .sidenav {


### PR DESCRIPTION
## Summary
- จัดองค์ประกอบในส่วน header ให้ชิดทางขวา
- ลดระยะห่างระหว่างโลโก้กับข้อความชื่อให้ใกล้กันมากขึ้น

## Testing
- `pytest` *(ล้มเหลว: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_688f3399efc0832b8a67dd819a1e37b2