### PR TITLE
ปรับความสูง header และจัดโลโก้ชิดซ้าย

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,5 +1,5 @@
 :root {
-  --header-height: 170px;
+  --header-height: 120px;
   --sidenav-width: 200px;
 }
 
@@ -17,13 +17,11 @@ header {
   height: var(--header-height);
   background-color: #e6f2ff;
   color: #003366;
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-    padding-left: 0;
-    padding-right: 20px;
-    box-sizing: border-box;
-    z-index: 1000;
+  display: flex;
+  align-items: center;
+  padding: 0 20px;
+  box-sizing: border-box;
+  z-index: 1000;
 }
 
 header h1 {
@@ -35,7 +33,7 @@ header h1 {
     height: calc(var(--header-height) - 20px);
     width: auto;
     object-fit: contain;
-    margin-right: 10px;
+    margin-right: 5px;
 }
 
 .sidenav {


### PR DESCRIPTION
## Summary
- ลดความสูงของ header เป็น 120px และจัดโลโก้กลับไปชิดซ้ายพร้อม padding แบบย่อเพื่อไม่ให้ CSS ซ้ำซ้อน

## Testing
- `pytest` *(ล้มเหลว: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_688f3399efc0832b8a67dd819a1e37b2