### PR TITLE
refactor: จัดการงานกล้องด้วยฟังก์ชัน generic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Add project root to sys.path for imports
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))


### PR DESCRIPTION
## Summary
- เพิ่มฟังก์ชัน `start_camera_task` และ `stop_camera_task` สำหรับควบคุมงานที่ใช้กล้อง
- ใช้ฟังก์ชันใหม่ใน route `/start_inference`, `/stop_inference`, `/start_roi_stream`, `/stop_roi_stream` เพื่อลดโค้ดซ้ำ
- เพิ่ม `tests/conftest.py` ให้สามารถนำเข้าโมดูลหลักระหว่างการทดสอบได้

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f3d99de60832b85b0efbaf8982260