### PR TITLE
refactor: add postgres pool

### DIFF
--- a/src/packages/config.py
+++ b/src/packages/config.py
@@ -1,0 +1,9 @@
+import os
+
+
+DB_HOST: str = os.getenv("DB_HOST", "localhost")
+DB_PORT: int = int(os.getenv("DB_PORT", "5432"))
+DB_NAME: str = os.getenv("DB_NAME", "nisitsirimarnkit")
+DB_USER: str = os.getenv("DB_USER", "postgres")
+DB_PASSWORD: str = os.getenv("DB_PASSWORD", "")
+

--- a/src/packages/db.py
+++ b/src/packages/db.py
@@ -1,0 +1,24 @@
+from psycopg2 import pool
+
+from . import config
+
+
+connection_pool = pool.SimpleConnectionPool(
+    1,
+    10,
+    host=config.DB_HOST,
+    port=config.DB_PORT,
+    database=config.DB_NAME,
+    user=config.DB_USER,
+    password=config.DB_PASSWORD,
+)
+
+
+def get_connection():
+    return connection_pool.getconn()
+
+
+def release_connection(conn):
+    if conn:
+        connection_pool.putconn(conn)
+

--- a/src/packages/models/yolov8/yolov8onnx/yolov8object/utils_posgres.py
+++ b/src/packages/models/yolov8/yolov8onnx/yolov8object/utils_posgres.py
@@ -1,43 +1,32 @@
+from psycopg2 import DatabaseError
 
-def conn_posgres(counter):
-    import psycopg2
+from packages.db import get_connection, release_connection
 
-    # Connect to the database
-    conn = psycopg2.connect(
-        host="localhost",
-        port="5432",
-        database="nisitsirimarnkit",
-        user="postgres",
-        password=""
-    )
 
-    # Create a cursor object
-    cur = conn.cursor()
+def conn_posgres(counter: int) -> bool:
+    conn = None
+    try:
+        conn = get_connection()
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT EXISTS (SELECT relname FROM pg_class WHERE relname = 'defect');"
+                )
+                table_exists = cur.fetchone()[0]
+                if not table_exists:
+                    cur.execute(
+                        "CREATE TABLE defect (id SERIAL PRIMARY KEY,timestamp TIMESTAMP NOT NULL DEFAULT (current_timestamp AT TIME ZONE 'Asia/bangkok'), detail VARCHAR(255), counter INTEGER)"
+                    )
+                cur.execute(
+                    "INSERT INTO defect (detail, counter) VALUES (%s, %s)",
+                    ("leak", counter),
+                )
+        return True
+    except DatabaseError as exc:
+        if conn:
+            conn.rollback()
+        print(f"Database error: {exc}")
+        return False
+    finally:
+        release_connection(conn)
 
-    # Check if the table exists
-    cur.execute("SELECT EXISTS (SELECT relname FROM pg_class WHERE relname = 'defect');")
-
-    # Fetch the result
-    table_exists = cur.fetchone()[0]
-
-    if not table_exists:
-        # Create the table
-        cur.execute("CREATE TABLE defect (id SERIAL PRIMARY KEY,timestamp TIMESTAMP NOT NULL DEFAULT (current_timestamp AT TIME ZONE 'Asia/bangkok'), detail VARCHAR(255), counter INTEGER)")
-
-        # Insert data into the table
-        cur.execute("INSERT INTO defect (detail, counter) VALUES (%s, %s)", ("leak", counter))
-
-        # Commit the changes to the database
-        conn.commit()
-    else:
-        print("Table already exists.")
-         # Insert data into the table
-        cur.execute("INSERT INTO defect (detail, counter) VALUES (%s, %s)", ("leak", counter))
-        # Commit the changes to the database
-        conn.commit()
-
-    # Close the cursor and connection
-    cur.close()
-    conn.close()
-
-# conn_posgres(4)


### PR DESCRIPTION
## Summary
- centralize PostgreSQL settings in config module
- create reusable connection pool helper
- update yolov8 utils to use pooled connections with error handling

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f3da2441c832b93bb4fd911b91f18