### PR TITLE
Specify WebSocket close code for ROI stream

### DIFF
--- a/app.py
+++ b/app.py
@@ -202,7 +202,7 @@ async def ws_roi():
     while True:
         frame_bytes = await roi_frame_queue.get()
         if frame_bytes is None:
-            await websocket.close()
+            await websocket.close(code=1000)
             break
         await websocket.send(frame_bytes)
 


### PR DESCRIPTION
## Summary
- add explicit `code=1000` when closing the ROI WebSocket to indicate normal closure

## Testing
- `pytest -q`
- manual start/stop ROI stream using dummy camera and quart stubs

------
https://chatgpt.com/codex/tasks/task_e_688f69d38a98832b9b542efb186b9e99