### PR TITLE
Resize inference frames

### DIFF
--- a/app.py
+++ b/app.py
@@ -95,7 +95,7 @@ async def read_and_queue_frame(
         await asyncio.sleep(0.1)
         return
     if frame_processor:
-        await frame_processor(frame)
+        frame = await frame_processor(frame)
     _, buffer = cv2.imencode('.jpg', frame)
     frame_bytes = buffer.tobytes() if hasattr(buffer, "tobytes") else buffer
     if queue.full():
@@ -149,6 +149,7 @@ async def run_inference_loop():
                     1,
                     cv2.LINE_AA,
                 )
+        return cv2.resize(frame, (0, 0), fx=0.5, fy=0.5)
 
     while True:
         await read_and_queue_frame(frame_queue, process_frame)

--- a/tests/test_event_loop.py
+++ b/tests/test_event_loop.py
@@ -55,6 +55,7 @@ cv2_stub.VideoCapture = DummyVideoCapture
 cv2_stub.imencode = lambda *a, **k: (True, b"data")
 cv2_stub.rectangle = lambda *a, **k: None
 cv2_stub.putText = lambda *a, **k: None
+cv2_stub.resize = lambda img, dsize, fx=0, fy=0, **k: img
 
 sys.modules["cv2"] = cv2_stub
 


### PR DESCRIPTION
## Summary
- ใช้ผลลัพธ์จาก `frame_processor` ในการอ่านเฟรม
- ลดขนาดเฟรมครึ่งหนึ่งหลังวาด ROI ในโหมด inference
- เพิ่ม stub `cv2.resize` ในการทดสอบ

## Testing
- `pytest`
- `pip install opencv-python-headless` *(ล้มเหลว: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689025b2a314832bb76b607341d0e6bb