### PR TITLE
ปรับขนาดวิดีโอในหน้า inference

### DIFF
--- a/templates/fragments/inference.html
+++ b/templates/fragments/inference.html
@@ -4,7 +4,7 @@
 <button id="stopButton" disabled>Stop</button>
 <p id="status"></p>
 <div style="position: relative; display: inline-block;">
-    <img id="video" width="640" height="480" />
+    <img id="video" width="320" height="240" />
 </div>
 
 <script>

--- a/templates/inference.html
+++ b/templates/inference.html
@@ -8,7 +8,7 @@
 <button id="stopButton" disabled>Stop</button>
 <p id="status"></p>
 <div style="position: relative; display: inline-block;">
-    <img id="video" width="640" height="480" />
+    <img id="video" width="320" height="240" />
 </div>
 <script>
 (function() {


### PR DESCRIPTION
## Summary
- ลดความกว้าง/สูงของ `<img id="video">` ในหน้า inference หลักและ fragment เพื่อให้เฟรมแสดงที่ 320x240

## Testing
- `pytest`
- พยายามรัน `python app.py` เพื่อตรวจสอบหน้าเว็บ แต่ล้มเหลวเพราะขาดโมดูล `quart`


------
https://chatgpt.com/codex/tasks/task_e_689025ba53e4832bac2247caecfc55c5