### PR TITLE
feat: support multiple camera cells

### DIFF
--- a/templates/fragments/inference.html
+++ b/templates/fragments/inference.html
@@ -1,126 +1,142 @@
 <h2>Inference with Saved ROI</h2>
-<select id="sourceSelect"></select>
-<button id="startButton">Start</button>
-<button id="stopButton" disabled>Stop</button>
-<p id="status"></p>
-<div style="position: relative; display: inline-block;">
-    <img id="video" width="320" height="240" />
+<div id="cam1" class="cam-cell">
+    <select id="cam1-sourceSelect"></select>
+    <button id="cam1-startButton">Start</button>
+    <button id="cam1-stopButton" disabled>Stop</button>
+    <p id="cam1-status"></p>
+    <div style="position: relative; display: inline-block;">
+        <img id="cam1-video" width="320" height="240" />
+    </div>
+</div>
+<div id="cam2" class="cam-cell">
+    <select id="cam2-sourceSelect"></select>
+    <button id="cam2-startButton">Start</button>
+    <button id="cam2-stopButton" disabled>Stop</button>
+    <p id="cam2-status"></p>
+    <div style="position: relative; display: inline-block;">
+        <img id="cam2-video" width="320" height="240" />
+    </div>
 </div>
 
 <script>
-    (function() {
+    function createCameraController(cellId) {
         let socket;
         let rois = [];
-        const video = document.getElementById("video");
+        const cam = cellId.replace(/\D/g, '');
+        const getEl = suffix => document.getElementById(`${cellId}-${suffix}`);
+        const video = getEl('video');
         video.onload = () => URL.revokeObjectURL(video.src);
-        const startButton = document.getElementById("startButton");
-        const stopButton = document.getElementById("stopButton");
-        const statusEl = document.getElementById("status");
+        const startButton = getEl('startButton');
+        const stopButton = getEl('stopButton');
+        const statusEl = getEl('status');
+        const sourceSelect = getEl('sourceSelect');
 
         startButton.onclick = startInference;
         stopButton.onclick = stopInference;
 
         async function loadSources() {
-            const res = await fetch("/source_list");
+            const res = await fetch(`/source_list?cam=${cam}`);
             const data = await res.json();
-            const select = document.getElementById("sourceSelect");
-            select.innerHTML = '';
+            sourceSelect.innerHTML = '';
             data.forEach(item => {
-                const opt = document.createElement("option");
+                const opt = document.createElement('option');
                 opt.value = item.name;
                 opt.textContent = item.name;
-                select.appendChild(opt);
+                sourceSelect.appendChild(opt);
             });
         }
 
         async function startInference() {
-        const name = document.getElementById("sourceSelect").value;
-        if (!name) {
-            statusEl.innerText = "Select source first";
-            return;
-        }
-        const cfg = await fetch(`/source_config?name=${encodeURIComponent(name)}`).then(r => r.json());
+            const name = sourceSelect.value;
+            if (!name) {
+                statusEl.innerText = 'Select source first';
+                return;
+            }
+            const cfg = await fetch(`/source_config?name=${encodeURIComponent(name)}`).then(r => r.json());
 
-        let roiPath = cfg.rois;
-        if (!roiPath.startsWith('/')) {
-            roiPath = `data_sources/${cfg.name}/${roiPath}`;
-        }
+            let roiPath = cfg.rois;
+            if (!roiPath.startsWith('/')) {
+                roiPath = `data_sources/${cfg.name}/${roiPath}`;
+            }
 
-        const camRes = await fetch("/set_camera", {
-            method: "POST",
-            headers: {"Content-Type": "application/json"},
-            body: JSON.stringify({ name, source: cfg.source, ...cfg })
-        });
-        if (!camRes.ok) {
-            statusEl.innerText = "Camera error";
-            return;
-        }
+            const camRes = await fetch(`/set_camera?cam=${cam}`, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({ name, source: cfg.source, ...cfg })
+            });
+            if (!camRes.ok) {
+                statusEl.innerText = 'Camera error';
+                return;
+            }
 
-        const res = await fetch(`/load_roi_file?path=${encodeURIComponent(roiPath)}`);
-        const data = await res.json();
-        statusEl.innerText = "Loaded: " + data.filename;
-        rois = data.rois;
+            const res = await fetch(`/load_roi_file?path=${encodeURIComponent(roiPath)}`);
+            const data = await res.json();
+            statusEl.innerText = 'Loaded: ' + data.filename;
+            rois = data.rois;
 
-        const startRes = await fetch("/start_inference", {
-            method: "POST",
-            headers: {"Content-Type": "application/json"},
-            body: JSON.stringify({ rois })
-        });
-        const startData = await startRes.json();
-        if (startData.status === "started" || startData.status === "already_running") {
-            openSocket();
-            setRunningUI();
-        }
+            const startRes = await fetch(`/start_inference?cam=${cam}`, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({ rois })
+            });
+            const startData = await startRes.json();
+            if (startData.status === 'started' || startData.status === 'already_running') {
+                openSocket();
+                setRunningUI();
+            }
         }
 
         async function stopInference() {
-        await fetch("/stop_inference", { method: "POST" });
-        if (socket) {
-            socket.close();
-            socket = null;
-        }
-        statusEl.innerText = "Stopped";
-        startButton.innerText = "Resume";
-        startButton.disabled = false;
-        stopButton.disabled = true;
-        }
-
-        function openSocket() {
-        socket = new WebSocket("ws://" + location.host + "/ws");
-        socket.binaryType = "arraybuffer";
-        socket.onmessage = function(event) {
-            const blob = new Blob([event.data], { type: "image/jpeg" });
-            video.src = URL.createObjectURL(blob);
-        };
-        }
-
-        async function checkStatus() {
-        const name = document.getElementById("sourceSelect").value;
-        const res = await fetch("/inference_status");
-        const data = await res.json();
-        if (data.running && name) {
-            openSocket();
-            setRunningUI();
-        } else {
-            statusEl.innerText = "Idle";
-            startButton.innerText = "Start";
+            await fetch(`/stop_inference?cam=${cam}`, { method: 'POST' });
+            if (socket) {
+                socket.close();
+                socket = null;
+            }
+            statusEl.innerText = 'Stopped';
+            startButton.innerText = 'Resume';
             startButton.disabled = false;
             stopButton.disabled = true;
         }
+
+        function openSocket() {
+            socket = new WebSocket(`ws://${location.host}/ws?cam=${cam}`);
+            socket.binaryType = 'arraybuffer';
+            socket.onmessage = function(event) {
+                const blob = new Blob([event.data], { type: 'image/jpeg' });
+                video.src = URL.createObjectURL(blob);
+            };
+        }
+
+        async function checkStatus() {
+            const name = sourceSelect.value;
+            const res = await fetch(`/inference_status?cam=${cam}`);
+            const data = await res.json();
+            if (data.running && name) {
+                openSocket();
+                setRunningUI();
+            } else {
+                statusEl.innerText = 'Idle';
+                startButton.innerText = 'Start';
+                startButton.disabled = false;
+                stopButton.disabled = true;
+            }
         }
 
         function setRunningUI() {
-        statusEl.innerText = "Running";
-        startButton.disabled = true;
-        stopButton.disabled = false;
-        startButton.innerText = "Start";
+            statusEl.innerText = 'Running';
+            startButton.disabled = true;
+            stopButton.disabled = false;
+            startButton.innerText = 'Start';
         }
 
         (async () => {
             await loadSources();
             await checkStatus();
         })();
+    }
 
-        // ไม่มีการวาด ROI ในฝั่งเบราว์เซอร์อีกต่อไป
-    })();
+    document.addEventListener('DOMContentLoaded', () => {
+        createCameraController('cam1');
+        createCameraController('cam2');
+    });
 </script>

--- a/templates/inference.html
+++ b/templates/inference.html
@@ -3,43 +3,56 @@
 
 {% block content %}
 <h2>Inference with Saved ROI</h2>
-<select id="sourceSelect"></select>
-<button id="startButton">Start</button>
-<button id="stopButton" disabled>Stop</button>
-<p id="status"></p>
-<div style="position: relative; display: inline-block;">
-    <img id="video" width="320" height="240" />
+<div id="cam1" class="cam-cell">
+    <select id="cam1-sourceSelect"></select>
+    <button id="cam1-startButton">Start</button>
+    <button id="cam1-stopButton" disabled>Stop</button>
+    <p id="cam1-status"></p>
+    <div style="position: relative; display: inline-block;">
+        <img id="cam1-video" width="320" height="240" />
+    </div>
+</div>
+<div id="cam2" class="cam-cell">
+    <select id="cam2-sourceSelect"></select>
+    <button id="cam2-startButton">Start</button>
+    <button id="cam2-stopButton" disabled>Stop</button>
+    <p id="cam2-status"></p>
+    <div style="position: relative; display: inline-block;">
+        <img id="cam2-video" width="320" height="240" />
+    </div>
 </div>
 <script>
-(function() {
+function createCameraController(cellId) {
     let socket;
     let rois = [];
-    const video = document.getElementById("video");
+    const cam = cellId.replace(/\D/g, '');
+    const getEl = suffix => document.getElementById(`${cellId}-${suffix}`);
+    const video = getEl('video');
     video.onload = () => URL.revokeObjectURL(video.src);
-    const startButton = document.getElementById("startButton");
-    const stopButton = document.getElementById("stopButton");
-    const statusEl = document.getElementById("status");
+    const startButton = getEl('startButton');
+    const stopButton = getEl('stopButton');
+    const statusEl = getEl('status');
+    const sourceSelect = getEl('sourceSelect');
 
     startButton.onclick = startInference;
     stopButton.onclick = stopInference;
 
     async function loadSources() {
-        const res = await fetch("/source_list");
+        const res = await fetch(`/source_list?cam=${cam}`);
         const data = await res.json();
-        const select = document.getElementById("sourceSelect");
-        select.innerHTML = '';
+        sourceSelect.innerHTML = '';
         data.forEach(item => {
-            const opt = document.createElement("option");
+            const opt = document.createElement('option');
             opt.value = item.name;
             opt.textContent = item.name;
-            select.appendChild(opt);
+            sourceSelect.appendChild(opt);
         });
     }
 
     async function startInference() {
-        const name = document.getElementById("sourceSelect").value;
+        const name = sourceSelect.value;
         if (!name) {
-            statusEl.innerText = "Select source first";
+            statusEl.innerText = 'Select source first';
             return;
         }
         const cfg = await fetch(`/source_config?name=${encodeURIComponent(name)}`).then(r => r.json());
@@ -49,80 +62,85 @@
             roiPath = `data_sources/${cfg.name}/${roiPath}`;
         }
 
-        const camRes = await fetch("/set_camera", {
-            method: "POST",
-            headers: {"Content-Type": "application/json"},
+        const camRes = await fetch(`/set_camera?cam=${cam}`, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({ name, source: cfg.source, ...cfg })
         });
         if (!camRes.ok) {
-            statusEl.innerText = "Camera error";
+            statusEl.innerText = 'Camera error';
             return;
         }
 
         const res = await fetch(`/load_roi_file?path=${encodeURIComponent(roiPath)}`);
         const data = await res.json();
-        statusEl.innerText = "Loaded: " + data.filename;
+        statusEl.innerText = 'Loaded: ' + data.filename;
         rois = data.rois;
 
-        const startRes = await fetch("/start_inference", {
-            method: "POST",
-            headers: {"Content-Type": "application/json"},
+        const startRes = await fetch(`/start_inference?cam=${cam}`, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({ rois })
         });
         const startData = await startRes.json();
-        if (startData.status === "started" || startData.status === "already_running") {
+        if (startData.status === 'started' || startData.status === 'already_running') {
             openSocket();
             setRunningUI();
         }
     }
 
     async function stopInference() {
-        await fetch("/stop_inference", { method: "POST" });
+        await fetch(`/stop_inference?cam=${cam}`, { method: 'POST' });
         if (socket) {
             socket.close();
             socket = null;
         }
-        statusEl.innerText = "Stopped";
-        startButton.innerText = "Resume";
+        statusEl.innerText = 'Stopped';
+        startButton.innerText = 'Resume';
         startButton.disabled = false;
         stopButton.disabled = true;
     }
 
     function openSocket() {
-        socket = new WebSocket("ws://" + location.host + "/ws");
-        socket.binaryType = "arraybuffer";
+        socket = new WebSocket(`ws://${location.host}/ws?cam=${cam}`);
+        socket.binaryType = 'arraybuffer';
         socket.onmessage = function(event) {
-            const blob = new Blob([event.data], { type: "image/jpeg" });
+            const blob = new Blob([event.data], { type: 'image/jpeg' });
             video.src = URL.createObjectURL(blob);
         };
     }
 
     async function checkStatus() {
-        const name = document.getElementById("sourceSelect").value;
-        const res = await fetch("/inference_status");
+        const name = sourceSelect.value;
+        const res = await fetch(`/inference_status?cam=${cam}`);
         const data = await res.json();
         if (data.running && name) {
             openSocket();
             setRunningUI();
         } else {
-            statusEl.innerText = "Idle";
-            startButton.innerText = "Start";
+            statusEl.innerText = 'Idle';
+            startButton.innerText = 'Start';
             startButton.disabled = false;
             stopButton.disabled = true;
         }
     }
 
     function setRunningUI() {
-        statusEl.innerText = "Running";
+        statusEl.innerText = 'Running';
         startButton.disabled = true;
         stopButton.disabled = false;
-        startButton.innerText = "Start";
+        startButton.innerText = 'Start';
     }
 
     (async () => {
         await loadSources();
         await checkStatus();
     })();
-})();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    createCameraController('cam1');
+    createCameraController('cam2');
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- introduce reusable createCameraController() to manage camera-specific events and sockets
- call the controller for cam1 and cam2
- send camera id to backend for source loading, inference start/stop and status checks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689029006000832b82aad5f1957fe449