### PR TITLE
Fix camera endpoint paths in templates

### DIFF
--- a/templates/fragments/inference.html
+++ b/templates/fragments/inference.html
@@ -31,12 +31,11 @@
         const statusEl = getEl('status');
         const sourceSelect = getEl('sourceSelect');
 
-
-            startButton.onclick = startInference;
-            stopButton.onclick = stopInference;
+        startButton.onclick = startInference;
+        stopButton.onclick = stopInference;
 
         async function loadSources() {
-            const res = await fetch(`/source_list?cam=${cam}`);
+            const res = await fetch('/source_list');
             const data = await res.json();
             sourceSelect.innerHTML = '';
             data.forEach(item => {
@@ -60,7 +59,7 @@
                 roiPath = `data_sources/${cfg.name}/${roiPath}`;
             }
 
-            const camRes = await fetch(`/set_camera?cam=${cam}`, {
+            const camRes = await fetch(`/set_camera/${cam}`, {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
                 body: JSON.stringify({ name, source: cfg.source, ...cfg })
@@ -75,7 +74,7 @@
             statusEl.innerText = 'Loaded: ' + data.filename;
             rois = data.rois;
 
-            const startRes = await fetch(`/start_inference?cam=${cam}`, {
+            const startRes = await fetch(`/start_inference/${cam}`, {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
                 body: JSON.stringify({ rois })
@@ -88,7 +87,7 @@
         }
 
         async function stopInference() {
-            await fetch(`/stop_inference?cam=${cam}`, { method: 'POST' });
+            await fetch(`/stop_inference/${cam}`, { method: 'POST' });
             if (socket) {
                 socket.close();
                 socket = null;
@@ -100,7 +99,7 @@
         }
 
         function openSocket() {
-            socket = new WebSocket(`ws://${location.host}/ws?cam=${cam}`);
+            socket = new WebSocket(`ws://${location.host}/ws/${cam}`);
             socket.binaryType = 'arraybuffer';
             socket.onmessage = function(event) {
                 const blob = new Blob([event.data], { type: 'image/jpeg' });
@@ -110,7 +109,7 @@
 
         async function checkStatus() {
             const name = sourceSelect.value;
-            const res = await fetch(`/inference_status?cam=${cam}`);
+            const res = await fetch(`/inference_status/${cam}`);
             const data = await res.json();
             if (data.running && name) {
                 openSocket();

--- a/templates/fragments/roi_selection.html
+++ b/templates/fragments/roi_selection.html
@@ -22,6 +22,7 @@
             let currentRoi = null;
             let currentSource = "";
             let initialized = false;
+            const cam = 1;
 
             const video = document.getElementById("video");
             const canvas = document.getElementById("canvas");
@@ -60,13 +61,13 @@
                 }
                 currentSource = name;
                 const cfg = await fetch(`/source_config?name=${encodeURIComponent(name)}`).then(r => r.json());
-                await fetch("/set_camera", {
+                await fetch(`/set_camera/${cam}`, {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify({ name, source: cfg.source })
                 });
-                await fetch("/start_roi_stream", { method: "POST" });
-                socket = new WebSocket("ws://" + location.host + "/ws_roi");
+                await fetch(`/start_roi_stream/${cam}`, { method: "POST" });
+                socket = new WebSocket(`ws://${location.host}/ws_roi/${cam}`);
                 socket.binaryType = "arraybuffer";
                 socket.onmessage = function(event) {
                     const blob = new Blob([event.data], { type: "image/jpeg" });
@@ -86,7 +87,7 @@
                     socket = null;
                 }
 
-                await fetch("/stop_roi_stream", { method: "POST" });
+                await fetch(`/stop_roi_stream/${cam}`, { method: "POST" });
 
             }
 

--- a/templates/inference.html
+++ b/templates/inference.html
@@ -22,130 +22,126 @@
     </div>
 </div>
 <script>
-function createCameraController(cellId) {
-    let socket;
-    let rois = [];
-    const cam = cellId.replace(/\D/g, '');
-    const getEl = suffix => document.getElementById(`${cellId}-${suffix}`);
-    const video = getEl('video');
-    video.onload = () => URL.revokeObjectURL(video.src);
-    const startButton = getEl('startButton');
-    const stopButton = getEl('stopButton');
-    const statusEl = getEl('status');
-    const sourceSelect = getEl('sourceSelect');
-
+    function createCameraController(cellId) {
+        let socket;
+        let rois = [];
+        const cam = cellId.replace(/\D/g, '');
+        const getEl = suffix => document.getElementById(`${cellId}-${suffix}`);
+        const video = getEl('video');
+        video.onload = () => URL.revokeObjectURL(video.src);
+        const startButton = getEl('startButton');
+        const stopButton = getEl('stopButton');
+        const statusEl = getEl('status');
+        const sourceSelect = getEl('sourceSelect');
 
         startButton.onclick = startInference;
         stopButton.onclick = stopInference;
 
-    async function loadSources() {
-        const res = await fetch(`/source_list?cam=${cam}`);
-        const data = await res.json();
-        sourceSelect.innerHTML = '';
-        data.forEach(item => {
-            const opt = document.createElement('option');
-            opt.value = item.name;
-            opt.textContent = item.name;
-            sourceSelect.appendChild(opt);
-        });
-    }
-
-    async function startInference() {
-        const name = sourceSelect.value;
-        if (!name) {
-            statusEl.innerText = 'Select source first';
-            return;
-
+        async function loadSources() {
+            const res = await fetch('/source_list');
+            const data = await res.json();
+            sourceSelect.innerHTML = '';
+            data.forEach(item => {
+                const opt = document.createElement('option');
+                opt.value = item.name;
+                opt.textContent = item.name;
+                sourceSelect.appendChild(opt);
+            });
         }
 
         async function startInference() {
             const name = sourceSelect.value;
             if (!name) {
-                statusEl.innerText = "Select source first";
+                statusEl.innerText = 'Select source first';
                 return;
             }
             const cfg = await fetch(`/source_config?name=${encodeURIComponent(name)}`).then(r => r.json());
 
-        const camRes = await fetch(`/set_camera?cam=${cam}`, {
-            method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({ name, source: cfg.source, ...cfg })
-        });
-        if (!camRes.ok) {
-            statusEl.innerText = 'Camera error';
-            return;
+            let roiPath = cfg.rois;
+            if (!roiPath.startsWith('/')) {
+                roiPath = `data_sources/${cfg.name}/${roiPath}`;
+            }
+
+            const camRes = await fetch(`/set_camera/${cam}`, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({ name, source: cfg.source, ...cfg })
+            });
+            if (!camRes.ok) {
+                statusEl.innerText = 'Camera error';
+                return;
+            }
+
+            const res = await fetch(`/load_roi_file?path=${encodeURIComponent(roiPath)}`);
+            const data = await res.json();
+            statusEl.innerText = 'Loaded: ' + data.filename;
+            rois = data.rois;
+
+            const startRes = await fetch(`/start_inference/${cam}`, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({ rois })
+            });
+            const startData = await startRes.json();
+            if (startData.status === 'started' || startData.status === 'already_running') {
+                openSocket();
+                setRunningUI();
+            }
         }
 
-        const res = await fetch(`/load_roi_file?path=${encodeURIComponent(roiPath)}`);
-        const data = await res.json();
-        statusEl.innerText = 'Loaded: ' + data.filename;
-        rois = data.rois;
-
-        const startRes = await fetch(`/start_inference?cam=${cam}`, {
-            method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({ rois })
-        });
-        const startData = await startRes.json();
-        if (startData.status === 'started' || startData.status === 'already_running') {
-            openSocket();
-            setRunningUI();
-
-        }
-
-    async function stopInference() {
-        await fetch(`/stop_inference?cam=${cam}`, { method: 'POST' });
-        if (socket) {
-            socket.close();
-            socket = null;
-        }
-        statusEl.innerText = 'Stopped';
-        startButton.innerText = 'Resume';
-        startButton.disabled = false;
-        stopButton.disabled = true;
-    }
-
-    function openSocket() {
-        socket = new WebSocket(`ws://${location.host}/ws?cam=${cam}`);
-        socket.binaryType = 'arraybuffer';
-        socket.onmessage = function(event) {
-            const blob = new Blob([event.data], { type: 'image/jpeg' });
-            video.src = URL.createObjectURL(blob);
-        };
-    }
-
-    async function checkStatus() {
-        const name = sourceSelect.value;
-        const res = await fetch(`/inference_status?cam=${cam}`);
-        const data = await res.json();
-        if (data.running && name) {
-            openSocket();
-            setRunningUI();
-        } else {
-            statusEl.innerText = 'Idle';
-            startButton.innerText = 'Start';
+        async function stopInference() {
+            await fetch(`/stop_inference/${cam}`, { method: 'POST' });
+            if (socket) {
+                socket.close();
+                socket = null;
+            }
+            statusEl.innerText = 'Stopped';
+            startButton.innerText = 'Resume';
             startButton.disabled = false;
             stopButton.disabled = true;
-
         }
 
-    function setRunningUI() {
-        statusEl.innerText = 'Running';
-        startButton.disabled = true;
-        stopButton.disabled = false;
-        startButton.innerText = 'Start';
+        function openSocket() {
+            socket = new WebSocket(`ws://${location.host}/ws/${cam}`);
+            socket.binaryType = 'arraybuffer';
+            socket.onmessage = function(event) {
+                const blob = new Blob([event.data], { type: 'image/jpeg' });
+                video.src = URL.createObjectURL(blob);
+            };
+        }
+
+        async function checkStatus() {
+            const name = sourceSelect.value;
+            const res = await fetch(`/inference_status/${cam}`);
+            const data = await res.json();
+            if (data.running && name) {
+                openSocket();
+                setRunningUI();
+            } else {
+                statusEl.innerText = 'Idle';
+                startButton.innerText = 'Start';
+                startButton.disabled = false;
+                stopButton.disabled = true;
+            }
+        }
+
+        function setRunningUI() {
+            statusEl.innerText = 'Running';
+            startButton.disabled = true;
+            stopButton.disabled = false;
+            startButton.innerText = 'Start';
+        }
+
+        (async () => {
+            await loadSources();
+            await checkStatus();
+        })();
     }
 
-    (async () => {
-        await loadSources();
-        await checkStatus();
-    })();
-}
-
-document.addEventListener('DOMContentLoaded', () => {
-    createCameraController('cam1');
-    createCameraController('cam2');
-});
-
+    document.addEventListener('DOMContentLoaded', () => {
+        createCameraController('cam1');
+        createCameraController('cam2');
+    });
 </script>
 {% endblock %}
+

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -27,6 +27,7 @@
         let currentRoi = null;
         let currentSource = "";
         let initialized = false;
+        const cam = 1;
 
         const video = document.getElementById("video");
         const canvas = document.getElementById("canvas");
@@ -68,13 +69,13 @@
             }
             currentSource = name;
             const cfg = await fetch(`/source_config?name=${encodeURIComponent(name)}`).then(r => r.json());
-            await fetch("/set_camera", {
+            await fetch(`/set_camera/${cam}`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ name, source: cfg.source })
             });
-            await fetch("/start_roi_stream", { method: "POST" });
-            socket = new WebSocket("ws://" + location.host + "/ws_roi");
+            await fetch(`/start_roi_stream/${cam}`, { method: "POST" });
+            socket = new WebSocket(`ws://${location.host}/ws_roi/${cam}`);
             socket.binaryType = "arraybuffer";
             socket.onmessage = function(event) {
                 const blob = new Blob([event.data], { type: "image/jpeg" });
@@ -92,7 +93,7 @@
                 socket.close();
                 socket = null;
             }
-            await fetch("/stop_roi_stream", { method: "POST" });
+            await fetch(`/stop_roi_stream/${cam}`, { method: "POST" });
         }
 
         canvas.onmousedown = (e) => {


### PR DESCRIPTION
## Summary
- correct camera path usage for inference WebSocket and controls
- fix ROI selection to start camera stream with explicit cam id

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68903d6f4974832b90d5c279e5b680eb