### PR TITLE
Fix inference camera selection and stream control

### DIFF
--- a/templates/fragments/inference.html
+++ b/templates/fragments/inference.html
@@ -92,6 +92,8 @@
                 socket.close();
                 socket = null;
             }
+            // clear last frame and update UI
+            video.src = '';
             statusEl.innerText = 'Stopped';
             startButton.innerText = 'Resume';
             startButton.disabled = false;
@@ -135,9 +137,8 @@
         })();
     }
 
-    document.addEventListener('DOMContentLoaded', () => {
-        createCameraController('cam1');
-        createCameraController('cam2');
-    });
+    // initialize controllers immediately (DOMContentLoaded already fired in fragments)
+    createCameraController('cam1');
+    createCameraController('cam2');
 
 </script>

--- a/templates/inference.html
+++ b/templates/inference.html
@@ -95,6 +95,8 @@
                 socket.close();
                 socket = null;
             }
+            // clear last frame and update UI
+            video.src = '';
             statusEl.innerText = 'Stopped';
             startButton.innerText = 'Resume';
             startButton.disabled = false;
@@ -138,10 +140,9 @@
         })();
     }
 
-    document.addEventListener('DOMContentLoaded', () => {
-        createCameraController('cam1');
-        createCameraController('cam2');
-    });
+    // initialize controllers immediately (DOMContentLoaded already fired in fragments)
+    createCameraController('cam1');
+    createCameraController('cam2');
 </script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Initialize camera controllers immediately on inference pages so source lists populate
- Clear video frame and reset UI when stopping inference streams

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68903f4cfd08832bae4894a986b83a9d