### PR TITLE
Clear ROI frame queue before starting stream

### DIFF
--- a/app.py
+++ b/app.py
@@ -362,6 +362,9 @@ async def stop_inference(cam_id: int):
 async def start_roi_stream(cam_id: int):
     if inference_tasks.get(cam_id) and not inference_tasks[cam_id].done():
         return jsonify({"status": "inference_running", "cam_id": cam_id}), 400
+    queue = get_roi_frame_queue(cam_id)
+    while not queue.empty():
+        queue.get_nowait()
     roi_tasks[cam_id], resp, status = await start_camera_task(
         cam_id, roi_tasks, run_roi_loop
     )


### PR DESCRIPTION
## Summary
- ล้างคิว `roi_frame_queues[cam_id]` ก่อนเริ่มงานสตรีม ROI เพื่อป้องกันเฟรมค้างจากการเริ่มใหม่

## Testing
- `pytest -q`
- ⚠️ พยายามรันการทดสอบเรียก `/start_roi_stream` หลายครั้งแต่พบว่า `quart` ไม่ได้ติดตั้งและไม่สามารถติดตั้งเพิ่มได้เนื่องจากข้อจำกัดของเครือข่าย

------
https://chatgpt.com/codex/tasks/task_e_6890849261b4832b90e8e9a32ea5d975