### PR TITLE
รักษาสถานะการสตรีม ROI เมื่อเปลี่ยนหน้า

### DIFF
--- a/templates/fragments/roi_selection.html
+++ b/templates/fragments/roi_selection.html
@@ -56,6 +56,11 @@
                     opt.textContent = item.name;
                     select.appendChild(opt);
                 });
+                const savedSource = localStorage.getItem('roiSource');
+                if (localStorage.getItem('roiStreaming') === 'true' && savedSource) {
+                    select.value = savedSource;
+                    await startStream();
+                }
             }
 
             async function startStream() {
@@ -88,6 +93,8 @@
                 stopBtn.disabled = false;
                 startBtn.innerText = 'Start';
                 isRunning = true;
+                localStorage.setItem('roiStreaming', 'true');
+                localStorage.setItem('roiSource', currentSource);
             }
 
             async function stopStream() {
@@ -101,6 +108,8 @@
                 startBtn.disabled = false;
                 stopBtn.disabled = true;
                 isRunning = false;
+                localStorage.removeItem('roiStreaming');
+                localStorage.removeItem('roiSource');
             }
 
             canvas.onmousedown = (e) => {

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -60,6 +60,12 @@
                 opt.textContent = item.name;
                 select.appendChild(opt);
             });
+
+            const savedSource = localStorage.getItem('roiSource');
+            if (localStorage.getItem('roiStreaming') === 'true' && savedSource) {
+                select.value = savedSource;
+                await startStream();
+            }
         }
 
         loadSources();
@@ -93,6 +99,8 @@
             isStreaming = true;
             startBtn.disabled = true;
             stopBtn.disabled = false;
+            localStorage.setItem('roiStreaming', 'true');
+            localStorage.setItem('roiSource', currentSource);
         }
 
         async function stopStream() {
@@ -105,6 +113,8 @@
             startBtn.disabled = false;
             startBtn.textContent = "Resume";
             stopBtn.disabled = true;
+            localStorage.removeItem('roiStreaming');
+            localStorage.removeItem('roiSource');
         }
 
         canvas.onmousedown = (e) => {


### PR DESCRIPTION
## สรุป
- บันทึกสถานะการสตรีมและแหล่งที่มาไว้ใน localStorage และเรียกเริ่มสตรีมอีกครั้งอัตโนมัติเมื่อกลับมา
- อัปเดตปุ่ม Start/Stop และล้างสถานะใน localStorage เมื่อหยุดสตรีม

## การทดสอบ
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891656b9710832bae3df2c177539e18