### PR TITLE
Reset ROI state on navigation

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -34,6 +34,9 @@
       document.querySelectorAll('.sidenav a').forEach(link => {
         link.addEventListener('click', async (e) => {
           e.preventDefault();
+          if (window.onPageUnload) {
+            window.onPageUnload();
+          }
           const url = link.getAttribute('href');
           const res = await fetch(url);
           const text = await res.text();
@@ -63,6 +66,9 @@
     attachMenuHandlers();
     setActiveLink(window.location.pathname);
     window.addEventListener('popstate', async () => {
+      if (window.onPageUnload) {
+        window.onPageUnload();
+      }
       const url = window.location.pathname;
       const res = await fetch(url);
       const text = await res.text();

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -60,12 +60,6 @@
                 opt.textContent = item.name;
                 select.appendChild(opt);
             });
-
-            const savedSource = localStorage.getItem('roiSource');
-            if (localStorage.getItem('roiStreaming') === 'true' && savedSource) {
-                select.value = savedSource;
-                await startStream();
-            }
         }
 
         loadSources();
@@ -99,8 +93,6 @@
             isStreaming = true;
             startBtn.disabled = true;
             stopBtn.disabled = false;
-            localStorage.setItem('roiStreaming', 'true');
-            localStorage.setItem('roiSource', currentSource);
         }
 
         async function stopStream() {
@@ -113,8 +105,6 @@
             startBtn.disabled = false;
             startBtn.textContent = "Resume";
             stopBtn.disabled = true;
-            localStorage.removeItem('roiStreaming');
-            localStorage.removeItem('roiSource');
         }
 
         canvas.onmousedown = (e) => {
@@ -253,6 +243,20 @@
         document.getElementById('saveBtn').addEventListener('click', saveAllRois);
         document.getElementById('clearBtn').addEventListener('click', clearAllRois);
 
+        function cleanup() {
+            if (isStreaming) {
+                stopStream();
+            }
+            rois = [];
+            currentSource = "";
+            const select = document.getElementById("sourceSelect");
+            if (select) {
+                select.value = "";
+            }
+            drawAllRois();
+        }
+
+        window.onPageUnload = cleanup;
         window.startStream = startStream;
         window.stopStream = stopStream;
         window.saveAllRois = saveAllRois;


### PR DESCRIPTION
## Summary
- Clear ROI selection and streaming when changing pages by invoking a global cleanup hook.
- Added page cleanup logic in ROI script to stop streams, reset selections, and remove ROIs.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68916a5d8c04832bab677c158d6d8581