### PR TITLE
แสดงจุดสีเมื่อเลือก ROI

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -135,6 +135,12 @@
                 ctx.strokeStyle = 'blue';
                 ctx.lineWidth = 2;
                 ctx.stroke();
+                r.points.forEach(p => {
+                    ctx.beginPath();
+                    ctx.arc(p.x, p.y, 3, 0, 2 * Math.PI);
+                    ctx.fillStyle = 'blue';
+                    ctx.fill();
+                });
                 if (r.id !== undefined) {
                     ctx.font = '16px sans-serif';
                     ctx.fillStyle = 'blue';
@@ -150,6 +156,12 @@
                 ctx.strokeStyle = 'red';
                 ctx.lineWidth = 2;
                 ctx.stroke();
+                currentPoints.forEach(p => {
+                    ctx.beginPath();
+                    ctx.arc(p.x, p.y, 3, 0, 2 * Math.PI);
+                    ctx.fillStyle = 'red';
+                    ctx.fill();
+                });
             }
         }
 


### PR DESCRIPTION
## Summary
- วาดจุดสีน้ำเงินบนมุมของ ROI ที่บันทึกไว้
- วาดจุดสีแดงบนจุดที่กำลังเลือกเพื่อให้เห็นตำแหน่งได้ชัดเจน

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68917ab07558832baf54900cb5e33498