### PR TITLE
Ensure ROI stream closes on navigation

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -31,11 +31,11 @@
     }
 
     function attachMenuHandlers() {
-      document.querySelectorAll('.sidenav a').forEach(link => {
+        document.querySelectorAll('.sidenav a').forEach(link => {
         link.addEventListener('click', async (e) => {
           e.preventDefault();
           if (window.onPageUnload) {
-            window.onPageUnload();
+            await window.onPageUnload();
           }
           const url = link.getAttribute('href');
           const res = await fetch(url);
@@ -65,11 +65,11 @@
     }
     attachMenuHandlers();
     setActiveLink(window.location.pathname);
-    window.addEventListener('popstate', async () => {
-      if (window.onPageUnload) {
-        window.onPageUnload();
-      }
-      const url = window.location.pathname;
+      window.addEventListener('popstate', async () => {
+        if (window.onPageUnload) {
+          await window.onPageUnload();
+        }
+        const url = window.location.pathname;
       const res = await fetch(url);
       const text = await res.text();
       const parser = new DOMParser();

--- a/templates/fragments/roi_selection.html
+++ b/templates/fragments/roi_selection.html
@@ -64,9 +64,11 @@
 
             async function startStream() {
                 if (isRunning) return;
+                isRunning = true;
                 const name = document.getElementById("sourceSelect").value;
                 if (!name) {
                     alert("Select source first");
+                    isRunning = false;
                     return;
                 }
                 currentSource = name;
@@ -91,13 +93,11 @@
                 startBtn.disabled = true;
                 stopBtn.disabled = false;
                 startBtn.innerText = 'Start';
-                isRunning = true;
                 localStorage.setItem('roiStreaming', 'true');
                 localStorage.setItem('roiSource', currentSource);
             }
 
             async function stopStream() {
-                if (!isRunning) return;
                 if (socket) {
                     socket.close();
                     socket = null;
@@ -273,10 +273,15 @@
             saveBtn.addEventListener('click', saveAllRois);
             clearBtn.addEventListener('click', clearAllRois);
 
+            async function cleanup() {
+                await stopStream();
+            }
+
             window.startStream = startStream;
             window.stopStream = stopStream;
             window.saveAllRois = saveAllRois;
             window.clearAllRois = clearAllRois;
+            window.onFragmentUnload = cleanup;
 
             loadSources();
         })();

--- a/templates/home.html
+++ b/templates/home.html
@@ -21,6 +21,10 @@
 
   <script>
     async function loadFragment(name) {
+      if (window.onFragmentUnload) {
+        await window.onFragmentUnload();
+        window.onFragmentUnload = null;
+      }
       const res = await fetch(`/fragment/${name}`);
       const html = await res.text();
       const content = document.getElementById('content');
@@ -38,10 +42,10 @@
     }
 
     document.querySelectorAll('.sidenav a').forEach(a => {
-      a.addEventListener('click', (e) => {
+      a.addEventListener('click', async (e) => {
         e.preventDefault();
         const frag = a.dataset.fragment;
-        loadFragment(frag);
+        await loadFragment(frag);
       });
     });
 

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -279,10 +279,8 @@
         document.getElementById('saveBtn').addEventListener('click', saveAllRois);
         document.getElementById('clearBtn').addEventListener('click', clearAllRois);
 
-        function cleanup() {
-            if (isStreaming) {
-                stopStream();
-            }
+        async function cleanup() {
+            await stopStream();
             rois = [];
             currentPoints = [];
             currentSource = "";


### PR DESCRIPTION
## Summary
- ensure async cleanup of ROI stream when switching menus
- add fragment unload hook so camera stops when leaving ROI tool

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68918786d978832ba2d3ff9414903af6