### PR TITLE
Reset onPageUnload after navigation

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -36,6 +36,7 @@
           e.preventDefault();
           if (window.onPageUnload) {
             await window.onPageUnload();
+            window.onPageUnload = null;
           }
           const url = link.getAttribute('href');
           const res = await fetch(url);
@@ -68,6 +69,7 @@
       window.addEventListener('popstate', async () => {
         if (window.onPageUnload) {
           await window.onPageUnload();
+          window.onPageUnload = null;
         }
         const url = window.location.pathname;
       const res = await fetch(url);


### PR DESCRIPTION
## Summary
- clear `window.onPageUnload` after invoking it during menu navigation to prevent stale handlers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68918bac1c6c832b921dede493f75cef