### PR TITLE
refactor: clean unused code and prevent leaks

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,8 @@ except Exception:  # pragma: no cover - fallback when numpy is missing
 import json
 import shutil
 import importlib.util
-import os, sys
+import os
+import sys
 from types import ModuleType
 from pathlib import Path
 import contextlib

--- a/src/packages/models/yolov8/yolov8onnx/yolov8object/YOLOv8.py
+++ b/src/packages/models/yolov8/yolov8onnx/yolov8object/YOLOv8.py
@@ -1,4 +1,3 @@
-import time
 import cv2
 import numpy as np
 import onnxruntime
@@ -131,7 +130,8 @@ class YOLOv8:
         for cx, cy, w, h in xywh:
             x = (cx - w / 2 - dw) / r
             y = (cy - h / 2 - dh) / r
-            w /= r; h /= r
+            w /= r
+            h /= r
             x, y = max(0, x), max(0, y)
             w, h = min(w0 - x, w), min(h0 - y, h)
             out.append([x, y, w, h])

--- a/src/packages/models/yolov8/yolov8onnx/yolov8object/YOLOv8_nippon.py
+++ b/src/packages/models/yolov8/yolov8onnx/yolov8object/YOLOv8_nippon.py
@@ -1,7 +1,6 @@
 import cv2
 import numpy as np
 import onnxruntime as ort
-import time
 
 
 class YOLOv8:

--- a/src/packages/models/yolov8/yolov8onnx/yolov8object/__init__.py
+++ b/src/packages/models/yolov8/yolov8onnx/yolov8object/__init__.py
@@ -1,1 +1,3 @@
 from .YOLOv8 import YOLOv8
+
+__all__ = ["YOLOv8"]

--- a/src/packages/models/yolov8/yolov8onnx/yolov8object/utils.py
+++ b/src/packages/models/yolov8/yolov8onnx/yolov8object/utils.py
@@ -1,5 +1,4 @@
 import numpy as np
-import cv2
 
 class_names = ['person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus', 'train', 'truck', 'boat', 'traffic light',
                'fire hydrant', 'stop sign', 'parking meter', 'bench', 'bird', 'cat', 'dog', 'horse', 'sheep', 'cow',

--- a/src/packages/models/yolov8/yolov8onnx/yolov8pose/YOLOv8Pose.py
+++ b/src/packages/models/yolov8/yolov8onnx/yolov8pose/YOLOv8Pose.py
@@ -3,7 +3,6 @@ import numpy as np
 import cv2
 import onnxruntime
 from typing import List, Tuple, Dict
-import base64
 # from utils import file_decode
 
 class YOLOv8Pose:
@@ -90,8 +89,7 @@ class YOLOv8Pose:
 
             crop_img = original_img[y1:y2, x1:x2]
             ret, jpeg = cv2.imencode('.jpg', crop_img)
-            img_b64 = base64.b64encode(jpeg.tobytes()).decode('utf-8')
-            # object_detect_list.append([img_b64, result_fall, score])
+            # object_detect_list.append([base64.b64encode(jpeg.tobytes()).decode('utf-8'), result_fall, score])
 
             label_str = "{:.0f}%".format(score*100)
             label_size, baseline = cv2.getTextSize(label_str, cv2.FONT_HERSHEY_SIMPLEX, 0.5, 2)
@@ -111,7 +109,6 @@ class YOLOv8Pose:
                     fontScale = 0.5
                     color = (0, 255, 255)
                     thickness = 1
-                    name_point = list(KEYPOINT_DICT.keys())[idx]
                     cv2.putText(img, '{}'.format(idx), center_point, font, fontScale, color, thickness, cv2.LINE_AA)
                     cv2.circle(img, (int(x), int(y)), 3, COLOR_LIST[idx], -1)
 
@@ -123,13 +120,6 @@ class YOLOv8Pose:
                     [255, 51, 51], [153, 255, 153], [102, 255, 102],
                     [51, 255, 51], [0, 255, 0], [0, 0, 255], [255, 0, 0],
                     [255, 255, 255]])
-            palette_fall = np.array([[0, 0, 255], [0, 0, 255], [0, 0, 255],
-                    [0, 0, 255], [0, 0, 255], [0, 0, 255],
-                    [0, 0, 255], [0, 0, 255], [0, 0, 255],
-                    [0, 0, 255], [0, 0, 255], [0, 0, 255],
-                    [0, 0, 255], [0, 0, 255], [0, 0, 255],
-                    [0, 0, 255], [0, 0, 255], [0, 0, 255], [0, 0, 255],
-                    [0, 0, 255]])
             skeleton = [[16, 14], [14, 12], [17, 15], [15, 13], [12, 13], [6, 12],
                 [7, 13], [6, 7], [6, 8], [7, 9], [8, 10], [9, 11], [2, 3],
                 [1, 2], [1, 3], [2, 4], [3, 5], [4, 6], [5, 7]]

--- a/src/packages/models/yolov8/yolov8onnx/yolov8pose/__init__.py
+++ b/src/packages/models/yolov8/yolov8onnx/yolov8pose/__init__.py
@@ -1,1 +1,3 @@
 from .YOLOv8Pose import YOLOv8Pose
+
+__all__ = ["YOLOv8Pose"]

--- a/src/packages/models/yolov8/yolov8onnx/yolov8seg/YOLOSeg.py
+++ b/src/packages/models/yolov8/yolov8onnx/yolov8seg/YOLOSeg.py
@@ -1,5 +1,4 @@
 import math
-import time
 import cv2
 import numpy as np
 import onnxruntime
@@ -54,10 +53,8 @@ class YOLOSeg:
         return input_tensor
 
     def inference(self, input_tensor):
-        start = time.perf_counter()
         outputs = self.session.run(self.output_names, {self.input_names[0]: input_tensor})
 
-        # print(f"Inference time: {(time.perf_counter() - start)*1000:.2f} ms")
         return outputs
 
     def process_box_output(self, box_output):

--- a/src/packages/models/yolov8/yolov8onnx/yolov8seg/__init__.py
+++ b/src/packages/models/yolov8/yolov8onnx/yolov8seg/__init__.py
@@ -1,1 +1,3 @@
 from .YOLOSeg import YOLOSeg
+
+__all__ = ["YOLOSeg"]


### PR DESCRIPTION
## Summary
- tidy Telegram notification helper by dropping unused byte file helpers and adding a `close` method to release HTTP sessions
- split combined imports and prune unused code across YOLOv8 model helpers

## Testing
- `ruff check app.py src/packages/notification/telegram_notify/telegram_notify.py src/packages/models/yolov8/yolov8onnx/yolov8object/YOLOv8.py src/packages/models/yolov8/yolov8onnx/yolov8object/YOLOv8_nippon.py src/packages/models/yolov8/yolov8onnx/yolov8object/__init__.py src/packages/models/yolov8/yolov8onnx/yolov8object/utils.py src/packages/models/yolov8/yolov8onnx/yolov8pose/YOLOv8Pose.py src/packages/models/yolov8/yolov8onnx/yolov8pose/__init__.py src/packages/models/yolov8/yolov8onnx/yolov8seg/YOLOSeg.py src/packages/models/yolov8/yolov8onnx/yolov8seg/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68918c84556c832b93df67c8e28457e3