### PR TITLE
Stop ROI stream without blocking navigation

### DIFF
--- a/templates/fragments/roi_selection.html
+++ b/templates/fragments/roi_selection.html
@@ -97,12 +97,16 @@
                 localStorage.setItem('roiSource', currentSource);
             }
 
-            async function stopStream() {
+            function stopStream() {
                 if (socket) {
                     socket.close();
                     socket = null;
                 }
-                await fetch(`/stop_roi_stream/${cam}`, { method: "POST" });
+                try {
+                    fetch(`/stop_roi_stream/${cam}`, { method: 'POST', keepalive: true });
+                } catch (err) {
+                    console.error('Failed to stop ROI stream', err);
+                }
                 startBtn.innerText = 'Resume';
                 startBtn.disabled = false;
                 stopBtn.disabled = true;
@@ -273,8 +277,12 @@
             saveBtn.addEventListener('click', saveAllRois);
             clearBtn.addEventListener('click', clearAllRois);
 
-            async function cleanup() {
-                await stopStream();
+            function cleanup() {
+                try {
+                    stopStream();
+                } catch (err) {
+                    console.error('Cleanup error', err);
+                }
             }
 
             window.startStream = startStream;

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -103,12 +103,16 @@
             stopBtn.disabled = false;
         }
 
-        async function stopStream() {
+        function stopStream() {
             if (socket) {
                 socket.close();
                 socket = null;
             }
-            await fetch(`/stop_roi_stream/${cam}`, { method: "POST" });
+            try {
+                fetch(`/stop_roi_stream/${cam}`, { method: 'POST', keepalive: true });
+            } catch (err) {
+                console.error('Failed to stop ROI stream', err);
+            }
             isStreaming = false;
             startBtn.disabled = false;
             startBtn.textContent = "Resume";
@@ -279,8 +283,12 @@
         document.getElementById('saveBtn').addEventListener('click', saveAllRois);
         document.getElementById('clearBtn').addEventListener('click', clearAllRois);
 
-        async function cleanup() {
-            await stopStream();
+        function cleanup() {
+            try {
+                stopStream();
+            } catch (err) {
+                console.error('Cleanup error', err);
+            }
             rois = [];
             currentPoints = [];
             currentSource = "";


### PR DESCRIPTION
## Summary
- avoid awaiting stopStream fetch in ROI templates to prevent navigation hang
- wrap cleanup and stopStream in try/catch and send keepalive POST

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68918e80d9b0832b9463ba5853b84b75