### PR TITLE
feat: persist roi stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ tg.start_send_text("สวัสดี")
 
 - **POST `/stop_roi_stream`** – หยุดส่งภาพ ROI
 
+- **GET `/roi_stream_status/<cam_id>`** – ตรวจสอบว่างาน ROI stream กำลังทำงานอยู่หรือไม่
+
 - **POST `/save_roi`** – บันทึก ROI ลงไฟล์ของ source หรือพาธที่กำหนด
   ```json
   {"source": "cam1", "rois": [{"x": 10, "y": 20, "width": 100, "height": 80}]}

--- a/app.py
+++ b/app.py
@@ -410,6 +410,15 @@ async def inference_status(cam_id: int):
     return jsonify({"running": running, "cam_id": cam_id})
 
 
+# ✅ สถานะงาน ROI stream
+@app.route('/roi_stream_status/<int:cam_id>', methods=["GET"])
+async def roi_stream_status(cam_id: int):
+    """เช็คว่างาน ROI stream กำลังทำงานอยู่หรือไม่"""
+    running = roi_tasks.get(cam_id) is not None and not roi_tasks[cam_id].done()
+    source = active_sources.get(cam_id, "")
+    return jsonify({"running": running, "cam_id": cam_id, "source": source})
+
+
 @app.route("/data_sources")
 async def list_sources():
     base_dir = Path(__file__).resolve().parent / "data_sources"

--- a/templates/fragments/roi_selection.html
+++ b/templates/fragments/roi_selection.html
@@ -55,10 +55,44 @@
                     opt.textContent = item.name;
                     select.appendChild(opt);
                 });
-                const savedSource = localStorage.getItem('roiSource');
-                if (localStorage.getItem('roiStreaming') === 'true' && savedSource) {
-                    select.value = savedSource;
-                    await startStream();
+            }
+
+            function openSocket() {
+                socket = new WebSocket(`ws://${location.host}/ws_roi/${cam}`);
+                socket.binaryType = "arraybuffer";
+                socket.onmessage = function(event) {
+                    const blob = new Blob([event.data], { type: "image/jpeg" });
+                    video.src = URL.createObjectURL(blob);
+                };
+                socket.onclose = function() {
+                    socket = null;
+                    isRunning = false;
+                    startBtn.disabled = false;
+                    startBtn.innerText = 'Resume';
+                    stopBtn.disabled = true;
+                    console.log("ROI stream closed");
+                };
+            }
+
+            async function checkStatus() {
+                const res = await fetch(`/roi_stream_status/${cam}`);
+                const data = await res.json();
+                if (data.running) {
+                    const select = document.getElementById('sourceSelect');
+                    if (data.source) {
+                        select.value = data.source;
+                        currentSource = data.source;
+                        await loadRois();
+                    }
+                    openSocket();
+                    isRunning = true;
+                    startBtn.disabled = true;
+                    startBtn.innerText = 'Start';
+                    stopBtn.disabled = false;
+                } else {
+                    startBtn.disabled = false;
+                    startBtn.innerText = 'Start';
+                    stopBtn.disabled = true;
                 }
             }
 
@@ -92,29 +126,12 @@
                     stopBtn.disabled = true;
                     return;
                 }
-                socket = new WebSocket(`ws://${location.host}/ws_roi/${cam}`);
-                socket.binaryType = "arraybuffer";
-                socket.onmessage = function(event) {
-                    const blob = new Blob([event.data], { type: "image/jpeg" });
-                    video.src = URL.createObjectURL(blob);
-                };
-                socket.onclose = function() {
-                    socket = null;
-                    isRunning = false;
-                    startBtn.disabled = false;
-                    startBtn.innerText = 'Start';
-                    stopBtn.disabled = true;
-                    localStorage.removeItem('roiStreaming');
-                    localStorage.removeItem('roiSource');
-                    console.log("ROI stream closed");
-                };
+                openSocket();
                 await loadRois();
                 isRunning = true;
                 startBtn.disabled = true;
                 stopBtn.disabled = false;
                 startBtn.innerText = 'Start';
-                localStorage.setItem('roiStreaming', 'true');
-                localStorage.setItem('roiSource', currentSource);
             }
 
             function stopStream() {
@@ -132,8 +149,6 @@
                 startBtn.disabled = false;
                 stopBtn.disabled = true;
                 isRunning = false;
-                localStorage.removeItem('roiStreaming');
-                localStorage.removeItem('roiSource');
             }
 
             canvas.addEventListener('click', (e) => {
@@ -298,20 +313,14 @@
             saveBtn.addEventListener('click', saveAllRois);
             clearBtn.addEventListener('click', clearAllRois);
 
-            function cleanup() {
-                try {
-                    stopStream();
-                } catch (err) {
-                    console.error('Cleanup error', err);
-                }
-            }
-
             window.startStream = startStream;
             window.stopStream = stopStream;
             window.saveAllRois = saveAllRois;
             window.clearAllRois = clearAllRois;
-            window.onFragmentUnload = cleanup;
 
-            loadSources();
+            (async () => {
+                await loadSources();
+                await checkStatus();
+            })();
         })();
     </script>

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -70,7 +70,44 @@
             });
         }
 
-        loadSources();
+        function openSocket() {
+            socket = new WebSocket(`ws://${location.host}/ws_roi/${cam}`);
+            socket.binaryType = "arraybuffer";
+            socket.onmessage = function(event) {
+                const blob = new Blob([event.data], { type: "image/jpeg" });
+                video.src = URL.createObjectURL(blob);
+            };
+            socket.onclose = function() {
+                socket = null;
+                isStreaming = false;
+                startBtn.disabled = false;
+                startBtn.textContent = "Resume";
+                stopBtn.disabled = true;
+                console.log("ROI stream closed");
+            };
+        }
+
+        async function checkStatus() {
+            const res = await fetch(`/roi_stream_status/${cam}`);
+            const data = await res.json();
+            if (data.running) {
+                const select = document.getElementById("sourceSelect");
+                if (data.source) {
+                    select.value = data.source;
+                    currentSource = data.source;
+                    await loadRois();
+                }
+                openSocket();
+                isStreaming = true;
+                startBtn.disabled = true;
+                startBtn.textContent = "Start";
+                stopBtn.disabled = false;
+            } else {
+                startBtn.disabled = false;
+                startBtn.textContent = "Start";
+                stopBtn.disabled = true;
+            }
+        }
 
         async function startStream() {
             if (isStreaming) return;
@@ -102,23 +139,11 @@
                 stopBtn.disabled = true;
                 return;
             }
-            socket = new WebSocket(`ws://${location.host}/ws_roi/${cam}`);
-            socket.binaryType = "arraybuffer";
-            socket.onmessage = function(event) {
-                const blob = new Blob([event.data], { type: "image/jpeg" });
-                video.src = URL.createObjectURL(blob);
-            };
-            socket.onclose = function() {
-                socket = null;
-                isStreaming = false;
-                startBtn.disabled = false;
-                startBtn.textContent = "Start";
-                stopBtn.disabled = true;
-                console.log("ROI stream closed");
-            };
+            openSocket();
             await loadRois();
             isStreaming = true;
             stopBtn.disabled = false;
+            startBtn.textContent = "Start";
         }
 
         function stopStream() {
@@ -302,27 +327,15 @@
         document.getElementById('saveBtn').addEventListener('click', saveAllRois);
         document.getElementById('clearBtn').addEventListener('click', clearAllRois);
 
-        function cleanup() {
-            try {
-                stopStream();
-            } catch (err) {
-                console.error('Cleanup error', err);
-            }
-            rois = [];
-            currentPoints = [];
-            currentSource = "";
-            const select = document.getElementById("sourceSelect");
-            if (select) {
-                select.value = "";
-            }
-            drawAllRois();
-        }
-
-        window.onPageUnload = cleanup;
         window.startStream = startStream;
         window.stopStream = stopStream;
         window.saveAllRois = saveAllRois;
         window.clearAllRois = clearAllRois;
+
+        (async () => {
+            await loadSources();
+            await checkStatus();
+        })();
     })();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow ROI streams to persist until explicitly stopped by adding `roi_stream_status` endpoint
- reconnect ROI selection pages to running streams and drop automatic cleanup
- document ROI stream status API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689195ce54d8832b8f64d944691a4acf