### PR TITLE
Limit concurrent starts for ROI and inference

### DIFF
--- a/templates/fragments/inference.html
+++ b/templates/fragments/inference.html
@@ -22,6 +22,7 @@
     function createCameraController(cellId) {
         let socket;
         let rois = [];
+        let running = false;
         const cam = cellId.replace(/\D/g, '');
         const getEl = suffix => document.getElementById(`${cellId}-${suffix}`);
         const video = getEl('video');
@@ -47,9 +48,14 @@
         }
 
         async function startInference() {
+            if (running) return;
+            running = true;
+            startButton.disabled = true;
             const name = sourceSelect.value;
             if (!name) {
                 statusEl.innerText = 'Select source first';
+                running = false;
+                startButton.disabled = false;
                 return;
             }
             const cfg = await fetch(`/source_config?name=${encodeURIComponent(name)}`).then(r => r.json());
@@ -66,6 +72,8 @@
             });
             if (!camRes.ok) {
                 statusEl.innerText = 'Camera error';
+                running = false;
+                startButton.disabled = false;
                 return;
             }
 
@@ -83,10 +91,15 @@
             if (startData.status === 'started' || startData.status === 'already_running') {
                 openSocket();
                 setRunningUI();
+            } else {
+                running = false;
+                startButton.disabled = false;
             }
         }
 
         async function stopInference() {
+            if (!running) return;
+            running = false;
             await fetch(`/stop_inference/${cam}`, { method: 'POST' });
             if (socket) {
                 socket.close();
@@ -116,11 +129,13 @@
             if (data.running && name) {
                 openSocket();
                 setRunningUI();
+                running = true;
             } else {
                 statusEl.innerText = 'Idle';
                 startButton.innerText = 'Start';
                 startButton.disabled = false;
                 stopButton.disabled = true;
+                running = false;
             }
         }
 

--- a/templates/fragments/roi_selection.html
+++ b/templates/fragments/roi_selection.html
@@ -22,6 +22,7 @@
             let currentSource = "";
             let initialized = false;
             let isRunning = false;
+            let hasStarted = false;
             const cam = 1;
 
             const video = document.getElementById("video");
@@ -67,8 +68,6 @@
                 socket.onclose = function() {
                     socket = null;
                     isRunning = false;
-                    startBtn.disabled = false;
-                    startBtn.innerText = 'Resume';
                     stopBtn.disabled = true;
                     console.log("ROI stream closed");
                 };
@@ -97,7 +96,9 @@
             }
 
             async function startStream() {
+                if (hasStarted) return;
                 if (isRunning) return;
+                hasStarted = true;
                 const name = document.getElementById("sourceSelect").value;
                 if (!name) {
                     alert("Select source first");
@@ -145,8 +146,6 @@
                     console.error('Failed to stop ROI stream', err);
                 }
                 video.src = "";
-                startBtn.innerText = 'Resume';
-                startBtn.disabled = false;
                 stopBtn.disabled = true;
                 isRunning = false;
             }

--- a/templates/inference.html
+++ b/templates/inference.html
@@ -25,6 +25,7 @@
     function createCameraController(cellId) {
         let socket;
         let rois = [];
+        let running = false;
         const cam = cellId.replace(/\D/g, '');
         const getEl = suffix => document.getElementById(`${cellId}-${suffix}`);
         const video = getEl('video');
@@ -50,9 +51,14 @@
         }
 
         async function startInference() {
+            if (running) return;
+            running = true;
+            startButton.disabled = true;
             const name = sourceSelect.value;
             if (!name) {
                 statusEl.innerText = 'Select source first';
+                running = false;
+                startButton.disabled = false;
                 return;
             }
             const cfg = await fetch(`/source_config?name=${encodeURIComponent(name)}`).then(r => r.json());
@@ -69,6 +75,8 @@
             });
             if (!camRes.ok) {
                 statusEl.innerText = 'Camera error';
+                running = false;
+                startButton.disabled = false;
                 return;
             }
 
@@ -86,10 +94,15 @@
             if (startData.status === 'started' || startData.status === 'already_running') {
                 openSocket();
                 setRunningUI();
+            } else {
+                running = false;
+                startButton.disabled = false;
             }
         }
 
         async function stopInference() {
+            if (!running) return;
+            running = false;
             await fetch(`/stop_inference/${cam}`, { method: 'POST' });
             if (socket) {
                 socket.close();
@@ -119,11 +132,13 @@
             if (data.running && name) {
                 openSocket();
                 setRunningUI();
+                running = true;
             } else {
                 statusEl.innerText = 'Idle';
                 startButton.innerText = 'Start';
                 startButton.disabled = false;
                 stopButton.disabled = true;
+                running = false;
             }
         }
 

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -33,6 +33,7 @@
         let currentSource = "";
         let initialized = false;
         let isStreaming = false;
+        let hasStarted = false;
         const cam = 1;
 
         const video = document.getElementById("video");
@@ -80,8 +81,6 @@
             socket.onclose = function() {
                 socket = null;
                 isStreaming = false;
-                startBtn.disabled = false;
-                startBtn.textContent = "Resume";
                 stopBtn.disabled = true;
                 console.log("ROI stream closed");
             };
@@ -110,7 +109,9 @@
         }
 
         async function startStream() {
+            if (hasStarted) return;
             if (isStreaming) return;
+            hasStarted = true;
             const name = document.getElementById("sourceSelect").value;
             if (!name) {
                 alert("Select source first");
@@ -158,8 +159,6 @@
             }
             video.src = "";
             isStreaming = false;
-            startBtn.disabled = false;
-            startBtn.textContent = "Resume";
             stopBtn.disabled = true;
         }
 


### PR DESCRIPTION
## Summary
- Ensure ROI start button only launches stream once
- Guard inference cells so each runs a single thread

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68919b94eaf4832b94543dab69da0b2d