### PR TITLE
chore: ignore Python cache directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Byte-compiled / optimized / DLL files
-__pycache__/
+**/__pycache__/
 *.py[codz]
 *$py.class
 


### PR DESCRIPTION
## Summary
- ปรับ `.gitignore` เพื่อไม่ให้ Git ติดตามโฟลเดอร์ `__pycache__`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68919e3e4018832b87a5670c362ea7f1