### PR TITLE
แก้ปัญหาวิดีโอช้าลงเมื่อกลับเข้าสู่หน้า ROI และ Inference

### DIFF
--- a/templates/inference.html
+++ b/templates/inference.html
@@ -153,11 +153,22 @@
             await loadSources();
             await checkStatus();
         })();
+
+        return { stopInference };
     }
 
     // initialize controllers immediately (DOMContentLoaded already fired in fragments)
-    createCameraController('cam1');
-    createCameraController('cam2');
+    const controllers = [
+        createCameraController('cam1'),
+        createCameraController('cam2')
+    ];
+
+    window.onPageUnload = async () => {
+        await Promise.all(controllers.map(c => c.stopInference()));
+    };
+    window.addEventListener('beforeunload', () => {
+        controllers.forEach(c => c.stopInference());
+    });
 </script>
 {% endblock %}
 

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -147,13 +147,13 @@
             startBtn.textContent = "Start";
         }
 
-        function stopStream() {
+        async function stopStream() {
             if (socket) {
                 socket.close();
                 socket = null;
             }
             try {
-                fetch(`/stop_roi_stream/${cam}`, { method: 'POST', keepalive: true });
+                await fetch(`/stop_roi_stream/${cam}`, { method: 'POST', keepalive: true });
             } catch (err) {
                 console.error('Failed to stop ROI stream', err);
             }
@@ -332,7 +332,7 @@
         window.clearAllRois = clearAllRois;
 
         window.onPageUnload = async () => {
-            stopStream();
+            await stopStream();
         };
         window.addEventListener('beforeunload', () => {
             stopStream();


### PR DESCRIPTION
## สรุป
- ปรับ stopStream ให้เป็น async และรอให้เซิร์ฟเวอร์หยุดสตรีมก่อนออกจากหน้า
- เพิ่ม onPageUnload ในหน้า Inference เพื่อหยุดงานที่ค้างอยู่เมื่อเปลี่ยนหน้า

## การทดสอบ
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891a00b6a44832b814994019435ae4f