### PR TITLE
Fix slow video stream after switching fragments

### DIFF
--- a/templates/fragments/inference.html
+++ b/templates/fragments/inference.html
@@ -150,10 +150,18 @@
             await loadSources();
             await checkStatus();
         })();
+
+        return { stopInference };
     }
 
     // initialize controllers immediately (DOMContentLoaded already fired in fragments)
-    createCameraController('cam1');
-    createCameraController('cam2');
+    const controllers = [
+        createCameraController('cam1'),
+        createCameraController('cam2')
+    ];
+
+    window.onFragmentUnload = async () => {
+        await Promise.all(controllers.map(c => c.stopInference()));
+    };
 
 </script>


### PR DESCRIPTION
## Summary
- ensure inference fragment closes sockets and stops cameras when leaving

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891b9eba3c4832bbc7ff894721c823f