### PR TITLE
Handle empty source list and fetch errors

### DIFF
--- a/templates/fragments/inference.html
+++ b/templates/fragments/inference.html
@@ -36,15 +36,34 @@
         stopButton.onclick = stopInference;
 
         async function loadSources() {
-            const res = await fetch('/source_list');
-            const data = await res.json();
-            sourceSelect.innerHTML = '';
-            data.forEach(item => {
+            try {
+                const res = await fetch('/source_list');
+                if (!res.ok) throw new Error('Bad response');
+                const data = await res.json();
+                sourceSelect.innerHTML = '';
+                if (data.length === 0) {
+                    const opt = document.createElement('option');
+                    opt.value = '';
+                    opt.textContent = 'No sources available';
+                    sourceSelect.appendChild(opt);
+                    statusEl.innerText = 'Create a source first';
+                } else {
+                    data.forEach(item => {
+                        const opt = document.createElement('option');
+                        opt.value = item.name;
+                        opt.textContent = item.name;
+                        sourceSelect.appendChild(opt);
+                    });
+                }
+            } catch (err) {
+                console.error('Failed to load sources', err);
+                sourceSelect.innerHTML = '';
                 const opt = document.createElement('option');
-                opt.value = item.name;
-                opt.textContent = item.name;
+                opt.value = '';
+                opt.textContent = 'Error loading sources';
                 sourceSelect.appendChild(opt);
-            });
+                statusEl.innerText = 'Error fetching sources';
+            }
         }
 
         async function startInference() {

--- a/templates/inference.html
+++ b/templates/inference.html
@@ -39,15 +39,34 @@
         stopButton.onclick = stopInference;
 
         async function loadSources() {
-            const res = await fetch('/source_list');
-            const data = await res.json();
-            sourceSelect.innerHTML = '';
-            data.forEach(item => {
+            try {
+                const res = await fetch('/source_list');
+                if (!res.ok) throw new Error('Bad response');
+                const data = await res.json();
+                sourceSelect.innerHTML = '';
+                if (data.length === 0) {
+                    const opt = document.createElement('option');
+                    opt.value = '';
+                    opt.textContent = 'No sources available';
+                    sourceSelect.appendChild(opt);
+                    statusEl.innerText = 'Create a source first';
+                } else {
+                    data.forEach(item => {
+                        const opt = document.createElement('option');
+                        opt.value = item.name;
+                        opt.textContent = item.name;
+                        sourceSelect.appendChild(opt);
+                    });
+                }
+            } catch (err) {
+                console.error('Failed to load sources', err);
+                sourceSelect.innerHTML = '';
                 const opt = document.createElement('option');
-                opt.value = item.name;
-                opt.textContent = item.name;
+                opt.value = '';
+                opt.textContent = 'Error loading sources';
                 sourceSelect.appendChild(opt);
-            });
+                statusEl.innerText = 'Error fetching sources';
+            }
         }
 
         async function startInference() {


### PR DESCRIPTION
## Summary
- handle empty `/source_list` responses and display fallback message
- add fetch error handling for source dropdown

## Testing
- `pytest -q`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'quart')*
- `pip install Quart -q` *(fails: Could not find a version that satisfies the requirement Quart)*

------
https://chatgpt.com/codex/tasks/task_e_6891c9a04988832b94c9b6d35672cd0f