### PR TITLE
fix: isolate inference controllers

### DIFF
--- a/templates/fragments/inference.html
+++ b/templates/fragments/inference.html
@@ -19,7 +19,8 @@
 </div>
 
 <script>
-    function createCameraController(cellId) {
+    (function() {
+        function createCameraController(cellId) {
         let socket;
         let rois = [];
         let running = false;
@@ -174,13 +175,14 @@
     }
 
     // initialize controllers immediately (DOMContentLoaded already fired in fragments)
-    const controllers = [
-        createCameraController('cam1'),
-        createCameraController('cam2')
-    ];
+        const controllers = [
+            createCameraController('cam1'),
+            createCameraController('cam2')
+        ];
 
-    window.onFragmentUnload = async () => {
-        await Promise.all(controllers.map(c => c.stopInference()));
-    };
+        window.onFragmentUnload = async () => {
+            await Promise.all(controllers.map(c => c.stopInference()));
+        };
+    })();
 
 </script>

--- a/templates/inference.html
+++ b/templates/inference.html
@@ -21,8 +21,9 @@
         <img id="cam2-video" width="320" height="240" />
     </div>
 </div>
-<script>
-    function createCameraController(cellId) {
+  <script>
+      (function() {
+      function createCameraController(cellId) {
         let socket;
         let rois = [];
         let running = false;
@@ -176,18 +177,19 @@
         return { stopInference };
     }
 
-    // initialize controllers immediately (DOMContentLoaded already fired in fragments)
-    const controllers = [
-        createCameraController('cam1'),
-        createCameraController('cam2')
-    ];
+  // initialize controllers immediately (DOMContentLoaded already fired in fragments)
+  const controllers = [
+      createCameraController('cam1'),
+      createCameraController('cam2')
+  ];
 
-    window.onPageUnload = async () => {
-        await Promise.all(controllers.map(c => c.stopInference()));
-    };
-    window.addEventListener('beforeunload', () => {
-        controllers.forEach(c => c.stopInference());
-    });
-</script>
+  window.onPageUnload = async () => {
+      await Promise.all(controllers.map(c => c.stopInference()));
+  };
+  window.addEventListener('beforeunload', () => {
+      controllers.forEach(c => c.stopInference());
+  });
+  })();
+  </script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- wrap inference fragment script in an IIFE so variables don't leak globally
- wrap full-page inference script in an IIFE for consistency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891cb332850832b83cec747eaa454d2