### PR TITLE
ให้ inference ทำงานต่อเมื่อปิดหน้าหรือเปลี่ยนคอนเทนต์

### DIFF
--- a/templates/fragments/inference.html
+++ b/templates/fragments/inference.html
@@ -175,14 +175,10 @@
     }
 
     // initialize controllers immediately (DOMContentLoaded already fired in fragments)
-        const controllers = [
-            createCameraController('cam1'),
-            createCameraController('cam2')
-        ];
-
-        window.onFragmentUnload = async () => {
-            await Promise.all(controllers.map(c => c.stopInference()));
-        };
+    const controllers = [
+        createCameraController('cam1'),
+        createCameraController('cam2')
+    ];
     })();
 
 </script>

--- a/templates/inference.html
+++ b/templates/inference.html
@@ -182,13 +182,6 @@
       createCameraController('cam1'),
       createCameraController('cam2')
   ];
-
-  window.onPageUnload = async () => {
-      await Promise.all(controllers.map(c => c.stopInference()));
-  };
-  window.addEventListener('beforeunload', () => {
-      controllers.forEach(c => c.stopInference());
-  });
   })();
   </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- ลบตัวจัดการ `onPageUnload` และ `beforeunload` จากหน้า inference เพื่อไม่ให้หยุดการทำงานโดยอัตโนมัติ
- ลบ `onFragmentUnload` ใน fragment inference ทำให้การสลับคอนเทนต์ไม่กระทบ thread inference

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891ce4f7c24832baf1670e0454e5357