### PR TITLE
Stop inference when fragment unloads

### DIFF
--- a/templates/inference.html
+++ b/templates/inference.html
@@ -182,6 +182,13 @@
       createCameraController('cam1'),
       createCameraController('cam2')
   ];
+
+  window.onPageUnload = async () => {
+      await Promise.all(controllers.map(c => c.stopInference()));
+  };
+  window.addEventListener('beforeunload', () => {
+      controllers.forEach(c => c.stopInference());
+  });
   })();
   </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Call `stopInference` on all controllers during fragment unload to close WebSockets and halt processing

## Testing
- `pytest`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'quart')*
- `pip install quart` *(fails: Could not find a version that satisfies the requirement quart)*

------
https://chatgpt.com/codex/tasks/task_e_6891d0fe1c0c832bbe07b3c9f416963a