### PR TITLE
Keep inference running after page close

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -178,9 +178,5 @@
       createCameraController('cam1'),
       createCameraController('cam2')
   ];
-
-  window.addEventListener('beforeunload', () => {
-      controllers.forEach(c => c.stopInference());
-  });
   })();
   </script>


### PR DESCRIPTION
## Summary
- remove browser unload handler so inference tasks keep running and can be stopped later

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891d8b39030832b89875edd65799abf