### PR TITLE
เพิ่ม logging ใน custom.py พร้อมจัดการเก็บ log 7 วัน

### DIFF
--- a/data_sources/test_source/custom.py
+++ b/data_sources/test_source/custom.py
@@ -1,10 +1,26 @@
 # data_sources/<your_source>/custom.py
+import logging
+import os
+from logging.handlers import TimedRotatingFileHandler
+
 from src.packages.models.yolov8.yolov8onnx.yolov8object.YOLOv8 import YOLOv8
+
+# ตั้งค่า logging โดยเก็บไฟล์ log ไว้ 7 วัน
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+_log_path = os.path.join(os.path.dirname(__file__), "custom.log")
+_handler = TimedRotatingFileHandler(_log_path, when="D", interval=1, backupCount=7)
+_formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+_handler.setFormatter(_formatter)
+logger.addHandler(_handler)
 
 # โหลดโมเดล (ใส่ path ไปยังไฟล์ .onnx ของคุณ)
 # model = YOLOv8("data_sources/<your_source>/model.onnx")
 
 def process(frame, roi_id=None):
+    """ประมวลผลเฟรมตาม ROI ที่ระบุและบันทึกค่าไว้ใน log"""
+    logger.info("process called with roi_id=%s", roi_id)
     # ตรวจจับวัตถุภายใน ROI ที่ระบุ
     # boxes, scores, class_ids = model(frame)
     # สามารถใช้ roi_id เพื่อตัดสินใจเพิ่มเติมได้


### PR DESCRIPTION
## Summary
- เพิ่มการตั้งค่า logging ใน custom.py พร้อมเก็บ log แบบหมุนเวียน 7 วัน
- บันทึกข้อมูล roi_id เมื่อเรียกใช้ฟังก์ชัน process

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892eb8059dc832baf2921b43c8969fe