### PR TITLE
เพิ่มการบันทึกรูป ROI1 ต่อเนื่องผ่าน custom.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,7 +15,6 @@ from pathlib import Path
 import contextlib
 import inspect
 from typing import Callable, Awaitable, Any
-from datetime import datetime
 try:  # pragma: no cover
     from websockets.exceptions import ConnectionClosed
 except Exception:  # websockets not installed
@@ -114,18 +113,22 @@ async def read_and_queue_frame(
         except asyncio.QueueEmpty:
             pass
     await queue.put(frame_bytes)
-    await asyncio.sleep(0.05)
+    await asyncio.sleep(0.04)
 
 
 async def run_inference_loop(cam_id: int):
     custom_module = load_custom_module(active_sources.get(cam_id, ""))
     process_fn = getattr(custom_module, "process", None) if custom_module else None
     process_has_id = False
+    process_has_save = False
     if process_fn:
         try:
-            process_has_id = len(inspect.signature(process_fn).parameters) >= 2
+            params = inspect.signature(process_fn).parameters
+            process_has_id = len(params) >= 2
+            process_has_save = len(params) >= 3
         except (ValueError, TypeError):
             process_has_id = False
+            process_has_save = False
 
     async def process_frame(frame):
         rois = inference_rois.get(cam_id, [])
@@ -160,23 +163,19 @@ async def run_inference_loop(cam_id: int):
                 )
                 matrix = cv2.getPerspectiveTransform(src, dst)
                 roi = cv2.warpPerspective(frame, matrix, (max_w, max_h))
-                if save_roi_flags.get(cam_id) and i == 0:
-                    source_name = active_sources.get(cam_id, "")
-                    save_dir = os.path.join("data_sources", source_name, "images", "roi1")
-                    os.makedirs(save_dir, exist_ok=True)
-                    filename = datetime.now().strftime("%Y%m%d%H%M%S") + ".jpg"
-                    file_path = os.path.join(save_dir, filename)
-                    try:
-                        await asyncio.to_thread(cv2.imwrite, file_path, roi)
-                    except Exception:
-                        pass
-                    save_roi_flags[cam_id] = False
+                save_flag = bool(save_roi_flags.get(cam_id) and i == 0)
                 if process_fn:
                     try:
                         if process_has_id:
-                            result = process_fn(roi, r.get("id", str(i)))
+                            if process_has_save:
+                                result = process_fn(roi, r.get("id", str(i)), save_flag)
+                            else:
+                                result = process_fn(roi, r.get("id", str(i)))
                         else:
-                            result = process_fn(roi)
+                            if process_has_save:
+                                result = process_fn(roi, save_flag)
+                            else:
+                                result = process_fn(roi)
                         if inspect.isawaitable(result):
                             await result
                     except Exception:

--- a/data_sources/test_source/custom.py
+++ b/data_sources/test_source/custom.py
@@ -7,6 +7,7 @@ import base64
 from logging.handlers import TimedRotatingFileHandler
 import logging
 import os
+from datetime import datetime
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -24,8 +25,15 @@ logger.addHandler(_handler)
 # ตัวแปรควบคุมเวลาเรียก OCR แยกตาม roi
 last_ocr_times = {}
 
-def process(frame, roi_id=None):
-    """ประมวลผล ROI และเรียก OCR เมื่อเวลาห่างจากครั้งก่อน >= 2 วินาที"""
+def process(frame, roi_id=None, save=False):
+    """ประมวลผล ROI และเรียก OCR เมื่อเวลาห่างจากครั้งก่อน >= 2 วินาที
+    บันทึกรูปภาพเมื่อระบุให้บันทึก"""
+    if save:
+        save_dir = os.path.join(os.path.dirname(__file__), "images", "roi1")
+        os.makedirs(save_dir, exist_ok=True)
+        filename = datetime.now().strftime("%Y%m%d%H%M%S%f") + ".jpg"
+        cv2.imwrite(os.path.join(save_dir, filename), frame)
+
     current_time = time.monotonic()
     last_time = last_ocr_times.get(roi_id)
 


### PR DESCRIPTION
## สรุป
- ปรับการทำงานของ `app.py` ให้ไม่รีเซตสถานะการบันทึก ROI1 ทำให้บันทึกภาพต่อเนื่องได้
- เพิ่มความละเอียดเวลาของชื่อไฟล์ใน `custom.py` เพื่อหลีกเลี่ยงการซ้ำเมื่อบันทึกหลายภาพต่อวินาที

## การทดสอบ
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68935650e284832b82da86f9a0b2d8ef