### PR TITLE
Allow saving multiple ROIs and group images by ROI ID

### DIFF
--- a/app.py
+++ b/app.py
@@ -163,7 +163,7 @@ async def run_inference_loop(cam_id: int):
                 )
                 matrix = cv2.getPerspectiveTransform(src, dst)
                 roi = cv2.warpPerspective(frame, matrix, (max_w, max_h))
-                save_flag = bool(save_roi_flags.get(cam_id) and i == 0)
+                save_flag = bool(save_roi_flags.get(cam_id))
                 if process_fn:
                     try:
                         if process_has_id:
@@ -180,8 +180,6 @@ async def run_inference_loop(cam_id: int):
                             await result
                     except Exception:
                         pass
-                if save_flag:
-                    save_roi_flags[cam_id] = False
                 cv2.polylines(frame, [src.astype(int)], True, (0, 255, 0), 2)
                 label_pt = src[0].astype(int)
                 cv2.putText(

--- a/data_sources/test_source/custom.py
+++ b/data_sources/test_source/custom.py
@@ -84,7 +84,7 @@ def process(frame, roi_id=None, save=False):
         logger.info(f"OCR skipped for ROI {roi_id} (throttled)")
 
     if save:
-        save_dir = os.path.join(os.path.dirname(__file__), "images", "roi1")
+        save_dir = os.path.join(os.path.dirname(__file__), "images", str(roi_id))
         os.makedirs(save_dir, exist_ok=True)
         filename = datetime.now().strftime("%Y%m%d%H%M%S%f") + ".jpg"
         path = os.path.join(save_dir, filename)


### PR DESCRIPTION
## Summary
- Save ROI frames for all regions without resetting flag
- Store ROI images under folders named by ROI ID

## Testing
- `pytest`
- manual: invoke `process` with stubbed deps to save multiple images per ROI

------
https://chatgpt.com/codex/tasks/task_e_68936bfb7374832b9f4fb0b54475ba88