### PR TITLE
feat: add module selection for ROI

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -31,6 +31,7 @@
         let currentPoints = [];
         let hoverPoint = null;
         let currentSource = "";
+        let modules = [];
         let initialized = false;
         let isStreaming = false;
         let hasStarted = false;
@@ -69,6 +70,17 @@
                 opt.textContent = item.name;
                 select.appendChild(opt);
             });
+        }
+
+        async function loadModules() {
+            try {
+                const res = await fetch('/inference_modules');
+                if (!res.ok) throw new Error('Bad response');
+                modules = await res.json();
+            } catch (err) {
+                console.error('Failed to load modules', err);
+                modules = [];
+            }
         }
 
         function openSocket() {
@@ -172,7 +184,11 @@
             if (currentPoints.length === 4) {
                 const roiId = prompt("ROI id?");
                 if (roiId !== null) {
-                    rois.push({ id: roiId, points: [...currentPoints] });
+                    let selectedModule = null;
+                    if (modules.length > 0) {
+                        selectedModule = prompt("Module? (" + modules.join(", ") + ")");
+                    }
+                    rois.push({ id: roiId, module: selectedModule, points: [...currentPoints] });
                 }
                 currentPoints = [];
                 hoverPoint = null;
@@ -272,6 +288,7 @@
                 }
                 return {
                     id: r.id ?? String(idx + 1),
+                    module: r.module ?? null,
                     points: pts || []
                 };
             });
@@ -337,6 +354,7 @@
 
         (async () => {
             await loadSources();
+            await loadModules();
             await checkStatus();
         })();
     })();

--- a/tests/test_roi_selection_save_all.py
+++ b/tests/test_roi_selection_save_all.py
@@ -1,0 +1,36 @@
+import json
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+def test_save_all_rois_payload():
+    html = Path('templates/roi_selection.html').read_text()
+    match = re.search(r"(function saveAllRois\s*\(\)\s*{[\s\S]*?})\n\s*function clearAllRois", html)
+    assert match, 'saveAllRois function not found'
+    func_text = match.group(1)
+
+    script = textwrap.dedent(
+        """
+        let rois = [
+          {id:'1', module:'m1', points:[{x:1,y:2}]},
+          {id:'2', module:'m2', points:[{x:3,y:4}]}
+        ];
+        let currentSource = 'src';
+        let fetchBody;
+        global.fetch = (url, opts) => { fetchBody = opts.body; return Promise.resolve({json: () => Promise.resolve({filename:'f'}), ok:true}); };
+        global.alert = () => {};
+        global.confirm = () => true;
+        function loadRois(){}
+        {func}
+        saveAllRois();
+        console.log(fetchBody);
+        """
+    ).replace('{func}', func_text)
+
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    body = json.loads(result.stdout.strip())
+    assert 'rois' in body
+    assert len(body['rois']) == 2
+    for roi in body['rois']:
+        assert set(['id', 'module', 'points']).issubset(roi.keys())


### PR DESCRIPTION
## Summary
- fetch inference modules on ROI page load and allow choosing module for each ROI
- keep module info when loading and saving ROIs
- add test verifying save payload includes module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68946abdbb6c832bb11bfb972002646b