### PR TITLE
feat: auto-save ROI module updates

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -296,6 +296,26 @@
             drawAllRois();
         }
 
+        async function saveRois() {
+            try {
+                const res = await fetch('/save_roi', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ rois, source: currentSource })
+                });
+                if (!res.ok) throw new Error('Failed to save');
+                alert('Saved');
+            } catch (err) {
+                alert('Error');
+                console.error('Failed to save ROIs', err);
+            }
+        }
+
+        function updateRoiModule(i, moduleName) {
+            rois[i].module = moduleName;
+            saveRois();
+        }
+
         function saveAllRois() {
             if (rois.length === 0) {
                 alert("No ROI selected.");
@@ -347,6 +367,7 @@
         window.stopStream = stopStream;
         window.saveAllRois = saveAllRois;
         window.clearAllRois = clearAllRois;
+        window.updateRoiModule = updateRoiModule;
 
         window.addEventListener('beforeunload', () => {
             stopStream();


### PR DESCRIPTION
## Summary
- add saveRois utility to persist current ROI data
- call saveRois in updateRoiModule and expose function globally

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894c2234aa0832bacb2804ea647a091