### PR TITLE
Fix ROI ID display in list

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -297,7 +297,10 @@
                 const w = Math.max(...xs) - x;
                 const h = Math.max(...ys) - y;
                 const tr = document.createElement('tr');
-                [r.id, x, y, w, h].forEach(val => {
+                const idTd = document.createElement('td');
+                idTd.textContent = r.id;
+                tr.appendChild(idTd);
+                [x, y, w, h].forEach(val => {
                     const td = document.createElement('td');
                     td.textContent = Math.round(val);
                     tr.appendChild(td);


### PR DESCRIPTION
## Summary
- Prevent ROI IDs from being rounded to NaN when rendering ROI list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894c4ff89c8832ba0fb2469127f130b