### PR TITLE
style: improve ROI list table readability

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -76,6 +76,25 @@ main {
   background-color: #ffffff;
 }
 
+/* Standard table styling */
+.roi-table {
+  border-collapse: collapse;
+  width: 100%;
+  margin-top: 10px;
+}
+.roi-table th,
+.roi-table td {
+  border: 1px solid #ccc;
+  padding: 8px;
+  text-align: center;
+}
+.roi-table th {
+  background-color: #f2f2f2;
+}
+.roi-table tr:nth-child(even) {
+  background-color: #f9f9f9;
+}
+
 .camera-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -278,6 +278,7 @@
             if (rois.length === 0) return;
 
             const table = document.createElement('table');
+            table.classList.add('roi-table');
             const thead = document.createElement('thead');
             const headerRow = document.createElement('tr');
             ['ID', 'x', 'y', 'w', 'h', 'Module'].forEach(col => {


### PR DESCRIPTION
## Summary
- style ROI table for better readability
- apply consistent table styling across pages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894c83fb368832ba025d882a69af957