### PR TITLE
Fix sidenav shrink on ROI start

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -46,6 +46,7 @@ header h1 {
   box-sizing: border-box;
   margin-top: var(--header-height);
   transition: width 0.3s ease;
+  flex-shrink: 0;
 }
 
 .sidenav a {


### PR DESCRIPTION
## Summary
- prevent the ROI page from shrinking the sidebar by disabling flex shrinking on `.sidenav`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689552e9fff0832bbdcde440e9923876