### PR TITLE
ปรับ side menu ให้ responsive และสูงเต็มหน้าจอ

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -6,7 +6,6 @@
 body {
   margin: 0;
   font-family: Arial, sans-serif;
-  display: flex;
   background-color: #ffffff;
 }
 
@@ -37,16 +36,18 @@ header h1 {
     margin-right: 5px;
 }
 
+/* Fixed side navigation */
 .sidenav {
+  position: fixed;
+  top: var(--header-height);
+  left: 0;
   width: var(--sidenav-width);
-  height: calc(100vh - var(--header-height));
+  bottom: 0;
   background-color: #e6f2ff;
-
   padding-top: 20px;
   box-sizing: border-box;
-  margin-top: var(--header-height);
   transition: width 0.3s ease;
-  flex-shrink: 0;
+  overflow-y: auto;
 }
 
 .sidenav a {
@@ -69,8 +70,7 @@ header h1 {
 
 main {
   margin-top: var(--header-height);
-  flex: 1;
-  margin-left: 0;
+  margin-left: var(--sidenav-width);
   padding: 20px;
   box-sizing: border-box;
   transition: margin-left 0.3s ease;


### PR DESCRIPTION
## Summary
- ปรับ `.sidenav` ให้เป็น fixed และปรับ `main` ให้ขยับตาม เพื่อให้ side menu ไม่ถูกเนื้อหาดันและแสดงเต็มหน้าจอ

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689556ac0178832bb0b7002e9e0e93c3