### PR TITLE
แก้ปุ่ม Start หน้า ROI และคงเฟรมสุดท้ายหลังหยุดสตรีม

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -98,6 +98,8 @@
                 socket = null;
                 isStreaming = false;
                 stopBtn.disabled = true;
+                startBtn.disabled = false;
+                hasStarted = false;
                 console.log("ROI stream closed");
             };
         }
@@ -173,9 +175,10 @@
             } catch (err) {
                 console.error('Failed to stop ROI stream', err);
             }
-            video.src = "";
             isStreaming = false;
+            hasStarted = false;
             stopBtn.disabled = true;
+            startBtn.disabled = false;
         }
 
         frameContainer.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- รีเซ็ตสถานะปุ่ม Start และ hasStarted เมื่อ WebSocket ปิดหรือกด Stop
- ไม่ล้าง video.src เพื่อให้เฟรมสุดท้ายยังปรากฏหลังหยุดสตรีม

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68958a18cfcc832ba96907e7677abbe2