### PR TITLE
feat: save roi on module change

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -414,6 +414,11 @@
 
         function updateRoiModule(i, module) {
             rois[i].module = module;
+            fetch('/save_roi', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ rois: rois, source: currentSource })
+            });
         }
 
         function deleteRoi(i) {

--- a/tests/test_roi_selection_update_module.py
+++ b/tests/test_roi_selection_update_module.py
@@ -1,0 +1,29 @@
+import json
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+def test_update_roi_module_triggers_save():
+    html = Path('templates/roi_selection.html').read_text()
+    match = re.search(r"function updateRoiModule\s*\(i, module\)\s*{[\s\S]*?}\n", html)
+    assert match, 'updateRoiModule function not found'
+    func_text = match.group(0)
+
+    script = textwrap.dedent(
+        f"""
+        let rois = [{{id:'1', module:'old', points:[{{x:1,y:2}}]}}];
+        let currentSource = 'src';
+        let fetchOpts;
+        global.fetch = (url, opts) => {{ fetchOpts = opts; return Promise.resolve({{}}); }};
+        {func_text}
+        updateRoiModule(0, 'new');
+        console.log(fetchOpts.body);
+        """
+    )
+
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    body = json.loads(result.stdout.strip())
+    assert body['rois'][0]['module'] == 'new'
+    assert body['source'] == 'src'


### PR DESCRIPTION
## Summary
- save ROI immediately when changing module
- add regression test for module saving

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68958f5295e0832ba643987cb43f240c