### PR TITLE
feat: display ROI grid and results in inference view

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -109,6 +109,25 @@ main {
   padding: 10px;
 }
 
+.roi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 80px);
+  gap: 4px;
+  margin-left: 10px;
+}
+
+.roi-item img {
+  width: 80px;
+  height: auto;
+  display: block;
+}
+
+.roi-item p {
+  margin: 2px 0 0;
+  font-size: 12px;
+  text-align: center;
+}
+
 @media (max-width: 600px) {
   :root {
     --sidenav-width: 150px;

--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -5,8 +5,11 @@
     <button id="cam1-startButton">Start</button>
     <button id="cam1-stopButton" disabled>Stop</button>
     <p id="cam1-status"></p>
-    <div style="position: relative; display: inline-block;">
-        <img id="cam1-video" width="320" height="240" />
+    <div style="display:flex;">
+        <div style="position: relative; display: inline-block;">
+            <img id="cam1-video" width="320" height="240" />
+        </div>
+        <div id="cam1-rois" class="roi-grid"></div>
     </div>
 </div>
 <div id="cam2" class="cam-cell">
@@ -14,14 +17,18 @@
     <button id="cam2-startButton">Start</button>
     <button id="cam2-stopButton" disabled>Stop</button>
     <p id="cam2-status"></p>
-    <div style="position: relative; display: inline-block;">
-        <img id="cam2-video" width="320" height="240" />
+    <div style="display:flex;">
+        <div style="position: relative; display: inline-block;">
+            <img id="cam2-video" width="320" height="240" />
+        </div>
+        <div id="cam2-rois" class="roi-grid"></div>
     </div>
 </div>
   <script>
       (function() {
       function createCameraController(cellId) {
         let socket;
+        let roiSocket;
         let rois = [];
         let running = false;
         const cam = cellId.replace(/\D/g, '');
@@ -32,6 +39,7 @@
         const stopButton = getEl('stopButton');
         const statusEl = getEl('status');
         const sourceSelect = getEl('sourceSelect');
+        const roiGrid = getEl('rois');
 
         startButton.onclick = startInference;
         stopButton.onclick = stopInference;
@@ -65,6 +73,21 @@
                 sourceSelect.appendChild(opt);
                 statusEl.innerText = 'Error fetching sources';
             }
+        }
+
+        function renderRoiPlaceholders() {
+            roiGrid.innerHTML = '';
+            rois.forEach(r => {
+                const item = document.createElement('div');
+                item.className = 'roi-item';
+                const img = document.createElement('img');
+                img.id = `${cellId}-roi-${r.id}`;
+                const p = document.createElement('p');
+                p.id = `${cellId}-text-${r.id}`;
+                item.appendChild(img);
+                item.appendChild(p);
+                roiGrid.appendChild(item);
+            });
         }
 
         async function startInference() {
@@ -102,6 +125,7 @@
             const data = await res.json();
             statusEl.innerText = 'Loaded: ' + data.filename;
             rois = data.rois;
+            renderRoiPlaceholders();
 
             const startRes = await fetch(`/start_inference/${cam}`, {
                 method: 'POST',
@@ -111,6 +135,7 @@
             const startData = await startRes.json();
             if (startData.status === 'started' || startData.status === 'already_running') {
                 openSocket();
+                openRoiSocket();
                 setRunningUI();
             } else {
                 running = false;
@@ -126,8 +151,13 @@
                 socket.close();
                 socket = null;
             }
+            if (roiSocket) {
+                roiSocket.close();
+                roiSocket = null;
+            }
             // clear last frame and update UI
             video.src = '';
+            roiGrid.innerHTML = '';
             statusEl.innerText = 'Stopped';
             startButton.innerText = 'Resume';
             startButton.disabled = false;
@@ -143,12 +173,41 @@
             };
         }
 
+        function openRoiSocket() {
+            roiSocket = new WebSocket(`ws://${location.host}/ws_roi_result/${cam}`);
+            roiSocket.onmessage = function(event) {
+                try {
+                    const data = JSON.parse(event.data);
+                    const imgEl = document.getElementById(`${cellId}-roi-${data.id}`);
+                    if (imgEl) {
+                        imgEl.src = `data:image/jpeg;base64,${data.image}`;
+                    }
+                    const textEl = document.getElementById(`${cellId}-text-${data.id}`);
+                    if (textEl) {
+                        textEl.textContent = data.text || '';
+                    }
+                } catch (e) {
+                    console.error('ROI message error', e);
+                }
+            };
+        }
+
         async function checkStatus() {
             const name = sourceSelect.value;
             const res = await fetch(`/inference_status/${cam}`);
             const data = await res.json();
             if (data.running && name) {
                 openSocket();
+                openRoiSocket();
+                const cfg = await fetch(`/source_config?name=${encodeURIComponent(name)}`).then(r => r.json());
+                let roiPath = cfg.rois;
+                if (!roiPath.startsWith('/')) {
+                    roiPath = `data_sources/${cfg.name}/${roiPath}`;
+                }
+                const roiRes = await fetch(`/load_roi_file?path=${encodeURIComponent(roiPath)}`);
+                const roiData = await roiRes.json();
+                rois = roiData.rois;
+                renderRoiPlaceholders();
                 setRunningUI();
                 running = true;
             } else {


### PR DESCRIPTION
## Summary
- stream ROI crops and text to frontend via new websocket
- render ROI images and recognition text in a grid beside each camera feed
- add supporting styles for ROI grid display

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689596a61448832ba3320d2619355699