### PR TITLE
Display ROI name and text with bounding boxes

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -116,13 +116,26 @@ main {
   margin-left: 10px;
 }
 
-.roi-item img {
+.roi-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.roi-title {
+  margin: 0;
+  font-size: 12px;
+  text-align: center;
+}
+
+.roi-image {
   width: 80px;
   height: auto;
   display: block;
+  border: 2px solid red;
 }
 
-.roi-item p {
+.roi-text {
   margin: 2px 0 0;
   font-size: 12px;
   text-align: center;

--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -80,10 +80,16 @@
             rois.forEach(r => {
                 const item = document.createElement('div');
                 item.className = 'roi-item';
+                const title = document.createElement('h4');
+                title.className = 'roi-title';
+                title.textContent = r.name || `ROI ${r.id}`;
                 const img = document.createElement('img');
                 img.id = `${cellId}-roi-${r.id}`;
+                img.className = 'roi-image';
                 const p = document.createElement('p');
                 p.id = `${cellId}-text-${r.id}`;
+                p.className = 'roi-text';
+                item.appendChild(title);
                 item.appendChild(img);
                 item.appendChild(p);
                 roiGrid.appendChild(item);


### PR DESCRIPTION
## Summary
- show ROI name above each result image and recognized text below
- add red bounding box styling for each ROI thumbnail

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68959931ad54832b8da08e090e333beb