### PR TITLE
Wrap inference cameras in cards

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -141,6 +141,14 @@ main {
   text-align: center;
 }
 
+.card {
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 10px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  margin-bottom: 20px;
+}
+
 @media (max-width: 600px) {
   :root {
     --sidenav-width: 150px;

--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -1,27 +1,31 @@
 <h2>Inference with Saved ROI</h2>
 <p>Modules are defined in the ROI file.</p>
-<div id="cam1" class="cam-cell">
-    <select id="cam1-sourceSelect"></select>
-    <button id="cam1-startButton">Start</button>
-    <button id="cam1-stopButton" disabled>Stop</button>
-    <p id="cam1-status"></p>
-    <div style="display:flex;">
-        <div style="position: relative; display: inline-block;">
-            <img id="cam1-video" width="320" height="240" />
+<div class="card">
+    <div id="cam1" class="cam-cell">
+        <select id="cam1-sourceSelect"></select>
+        <button id="cam1-startButton">Start</button>
+        <button id="cam1-stopButton" disabled>Stop</button>
+        <p id="cam1-status"></p>
+        <div style="display:flex;">
+            <div style="position: relative; display: inline-block;">
+                <img id="cam1-video" width="320" height="240" />
+            </div>
+            <div id="cam1-rois" class="roi-grid"></div>
         </div>
-        <div id="cam1-rois" class="roi-grid"></div>
     </div>
 </div>
-<div id="cam2" class="cam-cell">
-    <select id="cam2-sourceSelect"></select>
-    <button id="cam2-startButton">Start</button>
-    <button id="cam2-stopButton" disabled>Stop</button>
-    <p id="cam2-status"></p>
-    <div style="display:flex;">
-        <div style="position: relative; display: inline-block;">
-            <img id="cam2-video" width="320" height="240" />
+<div class="card">
+    <div id="cam2" class="cam-cell">
+        <select id="cam2-sourceSelect"></select>
+        <button id="cam2-startButton">Start</button>
+        <button id="cam2-stopButton" disabled>Stop</button>
+        <p id="cam2-status"></p>
+        <div style="display:flex;">
+            <div style="position: relative; display: inline-block;">
+                <img id="cam2-video" width="320" height="240" />
+            </div>
+            <div id="cam2-rois" class="roi-grid"></div>
         </div>
-        <div id="cam2-rois" class="roi-grid"></div>
     </div>
 </div>
   <script>


### PR DESCRIPTION
## Summary
- wrap each inference camera section in a card container
- add card styling to global stylesheet

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68959a38dc28832ba1d88cb264a8d172