### PR TITLE
Improve inference UI layout with separate ROI section

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -120,6 +120,10 @@ main {
   display: flex;
   flex-direction: column;
   align-items: center;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 4px;
+  background-color: #ffffff;
 }
 
 .roi-title {
@@ -147,6 +151,23 @@ main {
   padding: 10px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   margin-bottom: 20px;
+}
+
+.cam-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.video-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.roi-card {
+  display: flex;
+  align-items: flex-start;
 }
 
 @media (max-width: 600px) {

--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -1,31 +1,35 @@
 <h2>Inference with Saved ROI</h2>
 <p>Modules are defined in the ROI file.</p>
-<div class="card">
-    <div id="cam1" class="cam-cell">
-        <select id="cam1-sourceSelect"></select>
-        <button id="cam1-startButton">Start</button>
-        <button id="cam1-stopButton" disabled>Stop</button>
-        <p id="cam1-status"></p>
-        <div style="display:flex;">
-            <div style="position: relative; display: inline-block;">
+<div class="cam-row">
+    <div class="card">
+        <div id="cam1" class="cam-cell">
+            <select id="cam1-sourceSelect"></select>
+            <button id="cam1-startButton">Start</button>
+            <button id="cam1-stopButton" disabled>Stop</button>
+            <p id="cam1-status"></p>
+            <div class="video-wrapper">
                 <img id="cam1-video" width="320" height="240" />
             </div>
-            <div id="cam1-rois" class="roi-grid"></div>
         </div>
     </div>
+    <div class="card roi-card">
+        <div id="cam1-rois" class="roi-grid"></div>
+    </div>
 </div>
-<div class="card">
-    <div id="cam2" class="cam-cell">
-        <select id="cam2-sourceSelect"></select>
-        <button id="cam2-startButton">Start</button>
-        <button id="cam2-stopButton" disabled>Stop</button>
-        <p id="cam2-status"></p>
-        <div style="display:flex;">
-            <div style="position: relative; display: inline-block;">
+<div class="cam-row">
+    <div class="card">
+        <div id="cam2" class="cam-cell">
+            <select id="cam2-sourceSelect"></select>
+            <button id="cam2-startButton">Start</button>
+            <button id="cam2-stopButton" disabled>Stop</button>
+            <p id="cam2-status"></p>
+            <div class="video-wrapper">
                 <img id="cam2-video" width="320" height="240" />
             </div>
-            <div id="cam2-rois" class="roi-grid"></div>
         </div>
+    </div>
+    <div class="card roi-card">
+        <div id="cam2-rois" class="roi-grid"></div>
     </div>
 </div>
   <script>


### PR DESCRIPTION
## Summary
- Restructure inference UI so each camera video and its ROI grid appear in side-by-side cards
- Style ROI items and layout with borders for clearer presentation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895c7116e50832bbff27a741dae5b79