### PR TITLE
ปรับสไตล์การ์ดและ ROI ในหน้า inference

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -112,8 +112,9 @@ main {
 .roi-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, 80px);
-  gap: 4px;
+  gap: 8px;
   margin-left: 10px;
+  padding: 10px;
 }
 
 .roi-item {
@@ -121,8 +122,8 @@ main {
   flex-direction: column;
   align-items: center;
   border: 1px solid #ccc;
-  border-radius: 4px;
-  padding: 4px;
+  border-radius: 0;
+  padding: 6px;
   background-color: #ffffff;
 }
 
@@ -147,7 +148,7 @@ main {
 
 .card {
   border: 1px solid #ccc;
-  border-radius: 8px;
+  border-radius: 0;
   padding: 10px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   margin-bottom: 20px;


### PR DESCRIPTION
## Summary
- ปรับการ์ดบนหน้า inference ให้เป็นกรอบเหลี่ยมพร้อม padding
- เพิ่ม padding ให้ ROI grid และกำหนดแต่ละ ROI ให้มีกรอบเหลี่ยมพร้อมระยะห่าง

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895cb987acc832ba895e2984d5a585c