### PR TITLE
Integrate Bootstrap for UI components

### DIFF
--- a/static/js/bootstrap-init.js
+++ b/static/js/bootstrap-init.js
@@ -1,0 +1,4 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+  tooltipTriggerList.map(el => new bootstrap.Tooltip(el));
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,7 +2,8 @@
 <html>
 <head>
   <title>{% block title %}AI Stream Dashboard{% endblock %}</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}?v=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}?v=1">
 </head>
 <body>
   <header>
@@ -11,14 +12,16 @@
   </header>
   <div class="sidenav">
 
-    <a href="/home">🏠 Home</a>
-    <a href="/create_source">➕ Create Source</a>
-    <a href="/roi">📐 ROI Selection</a>
-    <a href="/inference">🤖 Inference</a>
+    <a href="/home" data-bs-toggle="tooltip" title="Home">🏠 Home</a>
+    <a href="/create_source" data-bs-toggle="tooltip" title="Create Source">➕ Create Source</a>
+    <a href="/roi" data-bs-toggle="tooltip" title="ROI Selection">📐 ROI Selection</a>
+    <a href="/inference" data-bs-toggle="tooltip" title="Inference">🤖 Inference</a>
   </div>
   <main id="content">
     {% block content %}{% endblock %}
   </main>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='js/bootstrap-init.js') }}"></script>
   <script>
     function setActiveLink(path) {
       document.querySelectorAll('.sidenav a').forEach(link => {

--- a/templates/create_source.html
+++ b/templates/create_source.html
@@ -2,43 +2,21 @@
 {% block title %}Create Source{% endblock %}
 {% block content %}
 
-<style>
-    table {
-        border-collapse: collapse;
-        width: 100%;
-        margin-top: 20px;
-    }
-    th, td {
-        border: 1px solid #ccc;
-        padding: 8px;
-    }
-    th {
-        background-color: #f0f0f0;
-    }
-    button.delete {
-        background-color: #e74c3c;
-        color: #fff;
-        border: none;
-        padding: 6px 12px;
-        cursor: pointer;
-    }
-</style>
-
 <h2>Create Source</h2>
-<form method="POST" action="/create_source">
-    <div>
-        <label for="name">Name:</label>
-        <input type="text" id="name" name="name" required>
+<form method="POST" action="/create_source" class="mb-4">
+    <div class="mb-3">
+        <label for="name" class="form-label">Name:</label>
+        <input type="text" id="name" name="name" class="form-control" required>
     </div>
-    <div>
-        <label for="source">Source:</label>
-        <input type="text" id="source" name="source" required>
+    <div class="mb-3">
+        <label for="source" class="form-label">Source:</label>
+        <input type="text" id="source" name="source" class="form-control" required>
     </div>
-    <button type="submit">Create</button>
+    <button type="submit" class="btn btn-primary">Create</button>
 </form>
 
 <h3>Source List</h3>
-<table>
+<table class="table table-bordered mt-3">
     <thead>
         <tr>
             <th>Name</th>
@@ -66,7 +44,7 @@
                 const actionTd = document.createElement('td');
                 const delBtn = document.createElement('button');
                 delBtn.textContent = 'Delete';
-                delBtn.classList.add('delete');
+                delBtn.className = 'btn btn-danger btn-sm';
                 delBtn.addEventListener('click', async () => {
                     if (confirm(`Delete ${src.name}?`)) {
                         const res = await fetch(`/delete_source/${encodeURIComponent(src.name)}`, {method: 'DELETE'});

--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -3,9 +3,9 @@
 <div class="cam-row">
     <div class="card">
         <div id="cam1" class="cam-cell">
-            <select id="cam1-sourceSelect"></select>
-            <button id="cam1-startButton">Start</button>
-            <button id="cam1-stopButton" disabled>Stop</button>
+            <select id="cam1-sourceSelect" class="form-select mb-2"></select>
+            <button id="cam1-startButton" class="btn btn-primary me-2">Start</button>
+            <button id="cam1-stopButton" class="btn btn-danger" disabled>Stop</button>
             <p id="cam1-status"></p>
             <div class="video-wrapper">
                 <img id="cam1-video" width="320" height="240" />
@@ -19,9 +19,9 @@
 <div class="cam-row">
     <div class="card">
         <div id="cam2" class="cam-cell">
-            <select id="cam2-sourceSelect"></select>
-            <button id="cam2-startButton">Start</button>
-            <button id="cam2-stopButton" disabled>Stop</button>
+            <select id="cam2-sourceSelect" class="form-select mb-2"></select>
+            <button id="cam2-startButton" class="btn btn-primary me-2">Start</button>
+            <button id="cam2-stopButton" class="btn btn-danger" disabled>Stop</button>
             <p id="cam2-status"></p>
             <div class="video-wrapper">
                 <img id="cam2-video" width="320" height="240" />

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -13,11 +13,11 @@
     }
 </style>
 
-<select id="sourceSelect"></select>
-<button id="startBtn">Start</button>
-<button id="stopBtn" disabled>Stop</button>
-<button id="saveBtn">Save All</button>
-<button id="clearBtn">Clear All</button>
+<select id="sourceSelect" class="form-select d-inline-block w-auto mb-2"></select>
+<button id="startBtn" class="btn btn-primary me-2">Start</button>
+<button id="stopBtn" class="btn btn-danger me-2" disabled>Stop</button>
+<button id="saveBtn" class="btn btn-success me-2">Save All</button>
+<button id="clearBtn" class="btn btn-secondary">Clear All</button>
 <br><br>
 <div id="frameContainer" style="position: relative; display: inline-block;">
     <img id="video" />
@@ -281,7 +281,7 @@
             if (rois.length === 0) return;
 
             const table = document.createElement('table');
-            table.classList.add('roi-table');
+            table.className = 'table table-striped table-sm';
             const thead = document.createElement('thead');
             const headerRow = document.createElement('tr');
             ['ID', 'x', 'y', 'w', 'h', 'Module', 'Delete'].forEach(col => {
@@ -311,6 +311,7 @@
                 });
                 const tdModule = document.createElement('td');
                 const select = document.createElement('select');
+                select.className = 'form-select form-select-sm';
                 const empty = document.createElement('option');
                 empty.value = '';
                 empty.textContent = '';
@@ -329,6 +330,7 @@
                 const tdDel = document.createElement('td');
                 const delBtn = document.createElement('button');
                 delBtn.textContent = 'Delete';
+                delBtn.className = 'btn btn-danger btn-sm';
                 delBtn.addEventListener('click', () => deleteRoi(idx));
                 tdDel.appendChild(delBtn);
                 tr.appendChild(tdDel);


### PR DESCRIPTION
## Summary
- add Bootstrap CDN to base layout and initialize tooltips
- update page templates to use Bootstrap classes for forms, tables, and buttons
- include simple Bootstrap tooltip initializer script

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895fe8ee344832b8a6ebcdce41ecbee