### PR TITLE
Include global alert partial for showAlert

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -18,6 +18,7 @@
     <a href="/roi" data-bs-toggle="tooltip" title="ROI Selection">📐 ROI Selection</a>
     <a href="/inference" data-bs-toggle="tooltip" title="Inference">🤖 Inference</a>
   </div>
+  {% include 'partials/alert.html' %}
   <main id="content">
     {% block content %}{% endblock %}
   </main>


### PR DESCRIPTION
## Summary
- include alert partial in base template so showAlert is always defined

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689610ff1e08832b9a0a61127c7a4959