### PR TITLE
แก้การจัดวาง content ให้ไม่โดน navbar บัง

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2,7 +2,6 @@ body {
   margin: 0;
   font-family: Arial, sans-serif;
   background-color: #ffffff;
-  padding-top: 70px;
 }
 
 .logo {
@@ -20,6 +19,7 @@ main {
   padding: 20px;
   box-sizing: border-box;
   background-color: #ffffff;
+  margin-top: 70px;
 }
 
 /* Standard table styling */

--- a/templates/base.html
+++ b/templates/base.html
@@ -28,7 +28,7 @@
     </div>
   </nav>
   {% include 'partials/alert.html' %}
-  <main id="content" class="container-fluid mt-4">
+  <main id="content" class="container-fluid">
     {% block content %}{% endblock %}
   </main>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- ปรับเลย์เอาต์เพื่อตั้งระยะห่างด้านบนของ main content
- ลบ margin class ที่ไม่จำเป็นจาก base template

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68968276347c832b94acd81951c9c3ca